### PR TITLE
Government menu to also have house and senate trading

### DIFF
--- a/gamestonk_terminal/README.md
+++ b/gamestonk_terminal/README.md
@@ -455,8 +455,16 @@ Command|Website
 `last_congress`         |last congress trading
 `buy_congress`          |top buy congress tickers
 `sell_congress`         |top sell congress tickers
+`last_senate`           |last senate trading
+`buy_senate`            |top buy senate tickers
+`sell_senate`           |top sell senate tickers
+`last_house`            |last house trading
+`buy_house`             |top buy house tickers
+`sell_house`            |top sell house tickers
 with ticker provided    |
 `congress`              | congress trades on the ticker
+`senate`                | senate trades on the ticker
+`house`                 | house trades on the ticker
 
 &nbsp;
 

--- a/gamestonk_terminal/README.md
+++ b/gamestonk_terminal/README.md
@@ -462,8 +462,11 @@ Command|Website
 `buy_house`             |top buy house tickers
 `sell_house`            |top sell house tickers
 with ticker provided    |
+`raw_congress`          | raw congress trades on the ticker
 `congress`              | congress trades on the ticker
+`raw_senate`            | raw senate trades on the ticker
 `senate`                | senate trades on the ticker
+`raw_house`             | raw house trades on the ticker
 `house`                 | house trades on the ticker
 
 &nbsp;

--- a/gamestonk_terminal/government/README.md
+++ b/gamestonk_terminal/government/README.md
@@ -9,11 +9,27 @@ This data has been provided by [quiverquant](https://www.quiverquant.com).
   * top buy congress tickers
 * [sell_congress](#sell_congress)
   * top sell congress tickers
+* [last_senate](#last_senate)
+  * last senate trading
+* [buy_senate](#buy_senate)
+  * top buy senate tickers
+* [sell_senate](#sell_senate)
+  * top sell senate tickers
+* [last_house](#last_house)
+  * last house trading
+* [buy_house](#buy_house)
+  * top buy house tickers
+* [sell_house](#sell_house)
+  * top sell house tickers
 
 #### WITH TICKER PROVIDED
 
 * [congress](#congress)
   * congress trades on the ticker
+* [senate](#senate)
+  * senate trades on the ticker
+* [house](#house)
+  * house trades on the ticker
 
 
 ## last_congress <a name="last_congress"></a>
@@ -50,6 +66,78 @@ Top sell congress trading. [Source: www.quiverquant.com]
 * -t : Number of top tickers. Default: 10.
 
 ![sold](https://user-images.githubusercontent.com/25267873/117505806-8c533180-af7c-11eb-8223-f11b08c72675.png)
+
+
+## last_senate <a name="last_senate"></a>
+```text
+usage: last_senate [-p PAST_TRANSACTIONS_DAYS]
+```
+Last senate trading. [Source: www.quiverquant.com]
+
+* -p : Past transaction days. Default: 5.
+* -r : Congress representative.
+
+<img width="994" alt="last_senate" src="https://user-images.githubusercontent.com/25267873/118394652-c936bc80-b63d-11eb-883d-a1fa690cc6cd.png">
+
+
+## buy_senate <a name="buy_senate"></a>
+```text
+usage: buy_senate [-p PAST_TRANSACTIONS_MONTHS] [-t TOP_NUM]
+```
+Top buy senate trading. [Source: www.quiverquant.com]
+
+* -p : Past transaction months. Default: 6.
+* -t : Number of top tickers. Default: 10.
+
+![buy_senate](https://user-images.githubusercontent.com/25267873/118394649-c89e2600-b63d-11eb-8ef2-e33d0e673626.png)
+
+
+## sell_senate <a name="sell_senate"></a>
+```text
+usage: sell_senate [-p PAST_TRANSACTIONS_MONTHS] [-t TOP_NUM]
+```
+Top sell senate trading. [Source: www.quiverquant.com]
+
+* -p : Past transaction months. Default: 6.
+* -t : Number of top tickers. Default: 10.
+
+![sell_senate](https://user-images.githubusercontent.com/25267873/118394647-c6d46280-b63d-11eb-9bca-761269fafd68.png)
+
+
+## last_house <a name="last_house"></a>
+```text
+usage: last_house [-p PAST_TRANSACTIONS_DAYS]
+```
+Last house trading. [Source: www.quiverquant.com]
+
+* -p : Past transaction days. Default: 5.
+* -r : Congress representative.
+
+<img width="991" alt="last_house" src="https://user-images.githubusercontent.com/25267873/118394650-c936bc80-b63d-11eb-8c9d-f4a3fe4a2aff.png">
+
+
+## buy_house <a name="buy_house"></a>
+```text
+usage: buy_house [-p PAST_TRANSACTIONS_MONTHS] [-t TOP_NUM]
+```
+Top buy house trading. [Source: www.quiverquant.com]
+
+* -p : Past transaction months. Default: 6.
+* -t : Number of top tickers. Default: 10.
+
+![buy_house](https://user-images.githubusercontent.com/25267873/118394648-c8058f80-b63d-11eb-99fa-5c1bf00d40b6.png)
+
+
+## sell_house <a name="sell_house"></a>
+```text
+usage: sell_house [-p PAST_TRANSACTIONS_MONTHS] [-t TOP_NUM]
+```
+Top sell house trading. [Source: www.quiverquant.com]
+
+* -p : Past transaction months. Default: 6.
+* -t : Number of top tickers. Default: 10.
+
+![sell_house](https://user-images.githubusercontent.com/25267873/118394645-c5a33580-b63d-11eb-8dbe-a9b9d948df24.png)
 
 
 ## congress <a name="congress"></a>

--- a/gamestonk_terminal/government/README.md
+++ b/gamestonk_terminal/government/README.md
@@ -150,3 +150,24 @@ Congress trading. [Source: www.quiverquant.com]
 
 ![congress](https://user-images.githubusercontent.com/25267873/117347548-280f6f80-aea1-11eb-8ee7-b511cdf863e1.png)
 
+
+## senate <a name="senate"></a>
+```text
+usage: senate [-p PAST_TRANSACTIONS_MONTHS]
+```
+Senate trading. [Source: www.quiverquant.com]
+
+* -p : Past transaction months. Default: 6.
+
+![senate](https://user-images.githubusercontent.com/25267873/118394689-187ced00-b63e-11eb-8943-4bd32466ff47.png)
+
+
+## house <a name="house"></a>
+```text
+usage: house [-p PAST_TRANSACTIONS_MONTHS]
+```
+House trading. [Source: www.quiverquant.com]
+
+* -p : Past transaction months. Default: 6.
+
+![house](https://user-images.githubusercontent.com/25267873/118394690-19158380-b63e-11eb-85ba-87fc2fd7df15.png)

--- a/gamestonk_terminal/government/README.md
+++ b/gamestonk_terminal/government/README.md
@@ -24,10 +24,16 @@ This data has been provided by [quiverquant](https://www.quiverquant.com).
 
 #### WITH TICKER PROVIDED
 
+* [raw_congress](#raw_congress)
+  * raw congress trades on the ticker
 * [congress](#congress)
   * congress trades on the ticker
+* [raw_senate](#raw_senate)
+  * raw senate trades on the ticke
 * [senate](#senate)
   * senate trades on the ticker
+* [raw_house](#raw_house)
+  * raw house trades on the ticker
 * [house](#house)
   * house trades on the ticker
 
@@ -140,6 +146,17 @@ Top sell house trading. [Source: www.quiverquant.com]
 ![sell_house](https://user-images.githubusercontent.com/25267873/118394645-c5a33580-b63d-11eb-8dbe-a9b9d948df24.png)
 
 
+## raw_congress <a name="raw_congress"></a>
+```text
+usage: raw_congress [-p PAST_TRANSACTIONS_DAYS]
+```
+Raw congress trading. [Source: www.quiverquant.com]
+
+* -p : Past transaction days. Default: 10.
+
+<img width="994" alt="raw_congress" src="https://user-images.githubusercontent.com/25267873/118398326-00ae6480-b650-11eb-804e-3194824c3685.png">
+
+
 ## congress <a name="congress"></a>
 ```text
 usage: congress [-p PAST_TRANSACTIONS_MONTHS]
@@ -151,6 +168,17 @@ Congress trading. [Source: www.quiverquant.com]
 ![congress](https://user-images.githubusercontent.com/25267873/117347548-280f6f80-aea1-11eb-8ee7-b511cdf863e1.png)
 
 
+## raw_senate <a name="raw_senate"></a>
+```text
+usage: raw_senate [-p PAST_TRANSACTIONS_DAYS]
+```
+Raw senate trading. [Source: www.quiverquant.com]
+
+* -p : Past transaction days. Default: 10.
+
+<img width="990" alt="raw_senate" src="https://user-images.githubusercontent.com/25267873/118398320-f8562980-b64f-11eb-9ad9-c64c12f9a3cf.png">
+
+
 ## senate <a name="senate"></a>
 ```text
 usage: senate [-p PAST_TRANSACTIONS_MONTHS]
@@ -160,6 +188,17 @@ Senate trading. [Source: www.quiverquant.com]
 * -p : Past transaction months. Default: 6.
 
 ![senate](https://user-images.githubusercontent.com/25267873/118394689-187ced00-b63e-11eb-8943-4bd32466ff47.png)
+
+
+## raw_house <a name="raw_house"></a>
+```text
+usage: raw_house [-p PAST_TRANSACTIONS_DAYS]
+```
+Raw house trading. [Source: www.quiverquant.com]
+
+* -p : Past transaction days. Default: 10.
+
+<img width="990" alt="raw_house" src="https://user-images.githubusercontent.com/25267873/118398317-f68c6600-b64f-11eb-898a-1d1d46c8f5c3.png">
 
 
 ## house <a name="house"></a>

--- a/gamestonk_terminal/government/gov_controller.py
+++ b/gamestonk_terminal/government/gov_controller.py
@@ -4,10 +4,10 @@ __docformat__ = "numpy"
 import argparse
 from typing import List
 from matplotlib import pyplot as plt
+from prompt_toolkit.completion import NestedCompleter
 from gamestonk_terminal import feature_flags as gtff
 from gamestonk_terminal.helper_funcs import get_flair
 from gamestonk_terminal.menu import session
-from prompt_toolkit.completion import NestedCompleter
 from gamestonk_terminal.government import quiverquant_view
 
 
@@ -23,14 +23,17 @@ class GovController:
         "buy_congress",
         "sell_congress",
         "congress",
+        "raw_congress",
         "last_senate",
         "buy_senate",
         "sell_senate",
         "senate",
+        "raw_senate",
         "last_house",
         "buy_house",
         "sell_house",
         "house",
+        "raw_house",
     ]
 
     def __init__(
@@ -45,7 +48,6 @@ class GovController:
             choices=self.CHOICES,
         )
 
-    @staticmethod
     def print_help(self):
         """Print help"""
 
@@ -67,8 +69,11 @@ class GovController:
         print("")
         if self.ticker:
             print(f"Ticker: {self.ticker}")
+            print("   raw_congress     raw congress trades on the ticker")
             print("   congress         congress trades on the ticker")
+            print("   raw_senate       raw senate trades on the ticker")
             print("   senate           senate trades on the ticker")
+            print("   raw_house        raw house trades on the ticker")
             print("   house            house trades on the ticker")
         print("")
         return
@@ -91,7 +96,7 @@ class GovController:
 
     def call_help(self, _):
         """Process Help command"""
-        self.print_help(self)
+        self.print_help()
 
     def call_q(self, _):
         """Process Q command - quit the menu"""
@@ -113,9 +118,13 @@ class GovController:
         """Process sell_congress command"""
         quiverquant_view.sell_government(other_args, "congress")
 
+    def call_raw_congress(self, other_args: List[str]):
+        """Process raw_congress command"""
+        quiverquant_view.raw_government(other_args, self.ticker, "congress")
+
     def call_congress(self, other_args: List[str]):
         """Process congress command"""
-        quiverquant_view.government(other_args, self.ticker, "congress")
+        quiverquant_view.government_trading(other_args, self.ticker, "congress")
 
     def call_last_senate(self, other_args: List[str]):
         """Process last_senate command"""
@@ -129,9 +138,13 @@ class GovController:
         """Process sell_senate command"""
         quiverquant_view.sell_government(other_args, "senate")
 
+    def call_raw_senate(self, other_args: List[str]):
+        """Process raw_senate command"""
+        quiverquant_view.raw_government(other_args, self.ticker, "senate")
+
     def call_senate(self, other_args: List[str]):
         """Process senate command"""
-        quiverquant_view.government(other_args, self.ticker, "senate")
+        quiverquant_view.government_trading(other_args, self.ticker, "senate")
 
     def call_last_house(self, other_args: List[str]):
         """Process last_house command"""
@@ -145,9 +158,13 @@ class GovController:
         """Process sell_house command"""
         quiverquant_view.sell_government(other_args, "house")
 
+    def call_raw_house(self, other_args: List[str]):
+        """Process raw_house command"""
+        quiverquant_view.raw_government(other_args, self.ticker, "house")
+
     def call_house(self, other_args: List[str]):
         """Process house command"""
-        quiverquant_view.government(other_args, self.ticker, "house")
+        quiverquant_view.government_trading(other_args, self.ticker, "house")
 
 
 def menu(ticker: str):

--- a/gamestonk_terminal/government/gov_controller.py
+++ b/gamestonk_terminal/government/gov_controller.py
@@ -23,6 +23,14 @@ class GovController:
         "buy_congress",
         "sell_congress",
         "congress",
+        "last_senate",
+        "buy_senate",
+        "sell_senate",
+        "senate",
+        "last_house",
+        "buy_house",
+        "sell_house",
+        "house",
     ]
 
     def __init__(
@@ -50,10 +58,18 @@ class GovController:
         print("   last_congress    last congress trading")
         print("   buy_congress     top buy congress tickers")
         print("   sell_congress    top sell congress tickers")
+        print("   last_senate      last senate trading")
+        print("   buy_senate       top buy senate tickers")
+        print("   sell_senate      top sell senate tickers")
+        print("   last_house       last house trading")
+        print("   buy_house        top buy house tickers")
+        print("   sell_house       top sell house tickers")
         print("")
         if self.ticker:
             print(f"Ticker: {self.ticker}")
             print("   congress         congress trades on the ticker")
+            print("   senate           senate trades on the ticker")
+            print("   house            house trades on the ticker")
         print("")
         return
 
@@ -87,19 +103,51 @@ class GovController:
 
     def call_last_congress(self, other_args: List[str]):
         """Process last_congress command"""
-        quiverquant_view.last_congress(other_args)
+        quiverquant_view.last_government(other_args, "congress")
 
     def call_buy_congress(self, other_args: List[str]):
         """Process buy_congress command"""
-        quiverquant_view.buy_congress(other_args)
+        quiverquant_view.buy_government(other_args, "congress")
 
     def call_sell_congress(self, other_args: List[str]):
         """Process sell_congress command"""
-        quiverquant_view.sell_congress(other_args)
+        quiverquant_view.sell_government(other_args, "congress")
 
     def call_congress(self, other_args: List[str]):
         """Process congress command"""
-        quiverquant_view.congress(other_args, self.ticker)
+        quiverquant_view.government(other_args, self.ticker, "congress")
+
+    def call_last_senate(self, other_args: List[str]):
+        """Process last_senate command"""
+        quiverquant_view.last_government(other_args, "senate")
+
+    def call_buy_senate(self, other_args: List[str]):
+        """Process buy_senate command"""
+        quiverquant_view.buy_government(other_args, "senate")
+
+    def call_sell_senate(self, other_args: List[str]):
+        """Process sell_senate command"""
+        quiverquant_view.sell_government(other_args, "senate")
+
+    def call_senate(self, other_args: List[str]):
+        """Process senate command"""
+        quiverquant_view.government(other_args, self.ticker, "senate")
+
+    def call_last_house(self, other_args: List[str]):
+        """Process last_house command"""
+        quiverquant_view.last_government(other_args, "house")
+
+    def call_buy_house(self, other_args: List[str]):
+        """Process buy_house command"""
+        quiverquant_view.buy_government(other_args, "house")
+
+    def call_sell_house(self, other_args: List[str]):
+        """Process sell_house command"""
+        quiverquant_view.sell_government(other_args, "house")
+
+    def call_house(self, other_args: List[str]):
+        """Process house command"""
+        quiverquant_view.government(other_args, self.ticker, "house")
 
 
 def menu(ticker: str):

--- a/gamestonk_terminal/government/quiverquant_model.py
+++ b/gamestonk_terminal/government/quiverquant_model.py
@@ -5,11 +5,13 @@ import pandas as pd
 API_QUIVERQUANT_KEY = "5cd2a65e96d0486efbe926a7cdbc1e8d8ab6c7b3"
 
 
-def get_congress_trading(ticker: str = "") -> pd.DataFrame:
-    """Returns the most recent transactions by members of U.S. Congress
+def get_government_trading(type: str, ticker: str = "") -> pd.DataFrame:
+    """Returns the most recent transactions by members of government
 
     Parameters
     ----------
+    type: str
+        Type of government data between: Congress, Senate and House
     ticker : str
         Ticker to get congress trading data from
 
@@ -19,10 +21,28 @@ def get_congress_trading(ticker: str = "") -> pd.DataFrame:
         Most recent transactions by members of U.S. Congress
     """
 
-    if ticker:
-        url = f"https://api.quiverquant.com/beta/historical/congresstrading/{ticker}"
+    if type == "congress":
+        if ticker:
+            url = (
+                f"https://api.quiverquant.com/beta/historical/congresstrading/{ticker}"
+            )
+        else:
+            url = "https://api.quiverquant.com/beta/live/congresstrading"
+
+    elif type == "senate":
+        if ticker:
+            url = f"https://api.quiverquant.com/beta/historical/senatetrading/{ticker}"
+        else:
+            url = "https://api.quiverquant.com/beta/live/senatetrading"
+
+    elif type == "house":
+        if ticker:
+            url = f"https://api.quiverquant.com/beta/historical/housetrading/{ticker}"
+        else:
+            url = "https://api.quiverquant.com/beta/live/housetrading"
+
     else:
-        url = "https://api.quiverquant.com/beta/live/congresstrading"
+        return pd.DataFrame()
 
     headers = {
         "accept": "application/json",
@@ -31,6 +51,8 @@ def get_congress_trading(ticker: str = "") -> pd.DataFrame:
     }
     response = requests.get(url, headers=headers)
     if response.status_code == 200:
-        return pd.DataFrame(response.json())
+        return pd.DataFrame(response.json()).rename(
+            columns={"Date": "TransactionDate", "Senator": "Representative"}
+        )
 
     return pd.DataFrame()

--- a/gamestonk_terminal/government/quiverquant_view.py
+++ b/gamestonk_terminal/government/quiverquant_view.py
@@ -201,10 +201,10 @@ def buy_government(other_args: List[str], gov_type: str):
 
         plt.figure(figsize=plot_autoscale(), dpi=PLOT_DPI)
 
-        df_gov.groupby("Ticker")["upper"].sum().sort_values(ascending=False).head(
-            n=ns_parser.top_num
-        ).plot(kind="bar", rot=0)
-        plt.ylabel("Amount [$]")
+        df_gov.groupby("Ticker")["upper"].sum().div(1000).sort_values(
+            ascending=False
+        ).head(n=ns_parser.top_num).plot(kind="bar", rot=0)
+        plt.ylabel("Amount [1k $]")
         plt.title(
             f"Top {ns_parser.top_num} most bought stocks since last {ns_parser.past_transactions_months} "
             "months (upper bound)"
@@ -301,10 +301,10 @@ def sell_government(other_args: List[str], gov_type: str):
 
         plt.figure(figsize=plot_autoscale(), dpi=PLOT_DPI)
 
-        df_gov.groupby("Ticker")["lower"].sum().sort_values().abs().head(
+        df_gov.groupby("Ticker")["lower"].sum().div(1000).sort_values().abs().head(
             n=ns_parser.top_num
         ).plot(kind="bar", rot=0)
-        plt.ylabel("Amount [$]")
+        plt.ylabel("Amount [1k $]")
         plt.title(
             f"Top {ns_parser.top_num} most sold stocks since last {ns_parser.past_transactions_months} months"
             " (upper bound)"

--- a/gamestonk_terminal/government/quiverquant_view.py
+++ b/gamestonk_terminal/government/quiverquant_view.py
@@ -14,20 +14,20 @@ from gamestonk_terminal.config_plot import PLOT_DPI
 from gamestonk_terminal import feature_flags as gtff
 
 
-def last_congress(other_args: List[str]):
-    """Last congress trading
+def last_government(other_args: List[str], type: str):
+    """Last government trading
 
     Parameters
     ----------
     other_args : List[str]
         Command line arguments to be processed with argparse
+    type: str
+        Type of government data between: congress, senate and house
     """
     parser = argparse.ArgumentParser(
         add_help=False,
-        prog="last_congress",
-        description="""
-            Last congress trading. [Source: www.quiverquant.com]
-        """,
+        prog="last_" + type,
+        description=f"Last {type} trading. [Source: www.quiverquant.com]",
     )
     parser.add_argument(
         "-p",
@@ -45,7 +45,7 @@ def last_congress(other_args: List[str]):
         dest="representative",
         type=str,
         default="",
-        help="Congress representative",
+        help="Representative",
     )
 
     try:
@@ -57,72 +57,83 @@ def last_congress(other_args: List[str]):
         if not ns_parser:
             return
 
-        df_congress = quiverquant_model.get_congress_trading()
+        df_gov = quiverquant_model.get_government_trading(type)
 
-        if df_congress.empty:
-            print("No congress trading data found\n")
+        if df_gov.empty:
+            print(f"No {type} trading data found\n")
             return
 
-        df_congress = df_congress.sort_values("TransactionDate", ascending=False)
+        df_gov = df_gov.sort_values("TransactionDate", ascending=False)
 
-        df_congress = df_congress[
-            df_congress["TransactionDate"].isin(
-                df_congress["TransactionDate"].unique()[
-                    : ns_parser.past_transactions_days
-                ]
+        df_gov = df_gov[
+            df_gov["TransactionDate"].isin(
+                df_gov["TransactionDate"].unique()[: ns_parser.past_transactions_days]
             )
         ]
 
-        df_congress = df_congress[
-            [
-                "TransactionDate",
-                "Ticker",
-                "Representative",
-                "Transaction",
-                "House",
-                "Range",
-                "ReportDate",
-            ]
-        ].rename(
-            columns={"TransactionDate": "Transaction Date", "ReportDate": "Report Date"}
-        )
+        if type == "congress":
+            df_gov = df_gov[
+                [
+                    "TransactionDate",
+                    "Ticker",
+                    "Representative",
+                    "Transaction",
+                    "Range",
+                    "House",
+                    "ReportDate",
+                ]
+            ].rename(
+                columns={
+                    "TransactionDate": "Transaction Date",
+                    "ReportDate": "Report Date",
+                }
+            )
+        else:
+            df_gov = df_gov[
+                [
+                    "TransactionDate",
+                    "Ticker",
+                    "Representative",
+                    "Transaction",
+                    "Range",
+                ]
+            ].rename(columns={"TransactionDate": "Transaction Date"})
 
         if ns_parser.representative:
-            df_congress_rep = df_congress[
-                df_congress["Representative"].str.split().str[0]
-                == ns_parser.representative
+            df_gov_rep = df_gov[
+                df_gov["Representative"].str.split().str[0] == ns_parser.representative
             ]
 
-            if df_congress_rep.empty:
+            if df_gov_rep.empty:
                 print(
                     f"No representative {ns_parser.representative} found in the past {ns_parser.past_transactions_days}"
                     f" days. The following are available: "
-                    f"{', '.join(df_congress['Representative'].str.split().str[0].unique())}"
+                    f"{', '.join(df_gov['Representative'].str.split().str[0].unique())}"
                 )
             else:
-                print(df_congress_rep.to_string(index=False))
+                print(df_gov_rep.to_string(index=False))
         else:
-            print(df_congress.to_string(index=False))
+            print(df_gov.to_string(index=False))
         print("")
 
     except Exception as e:
         print(e, "\n")
 
 
-def buy_congress(other_args: List[str]):
-    """Top buy congress trading
+def buy_government(other_args: List[str], type: str):
+    """Top buy government trading
 
     Parameters
     ----------
     other_args : List[str]
         Command line arguments to be processed with argparse
+    type: str
+        Type of government data between: congress, senate and house
     """
     parser = argparse.ArgumentParser(
         add_help=False,
-        prog="buy_congress",
-        description="""
-            Top buy congress trading. [Source: www.quiverquant.com]
-        """,
+        prog="buy_" + type,
+        description=f"Top buy {type} trading. [Source: www.quiverquant.com]",
     )
     parser.add_argument(
         "-p",
@@ -148,49 +159,49 @@ def buy_congress(other_args: List[str]):
         if not ns_parser:
             return
 
-        df_congress = quiverquant_model.get_congress_trading()
+        df_gov = quiverquant_model.get_government_trading(type)
 
-        if df_congress.empty:
-            print("No congress trading data found\n")
+        if df_gov.empty:
+            print(f"No {type} trading data found\n")
             return
 
-        df_congress = df_congress.sort_values("TransactionDate", ascending=False)
+        df_gov = df_gov.sort_values("TransactionDate", ascending=False)
 
         start_date = datetime.now() - timedelta(
             days=ns_parser.past_transactions_months * 30
         )
 
-        df_congress["TransactionDate"] = pd.to_datetime(df_congress["TransactionDate"])
+        df_gov["TransactionDate"] = pd.to_datetime(df_gov["TransactionDate"])
 
-        df_congress = df_congress[df_congress["TransactionDate"] > start_date].dropna()
+        df_gov = df_gov[df_gov["TransactionDate"] > start_date].dropna()
 
-        df_congress["min"] = df_congress["Range"].apply(
+        df_gov["min"] = df_gov["Range"].apply(
             lambda x: x.split("-")[0].strip("$").replace(",", "").strip()
         )
-        df_congress["max"] = df_congress["Range"].apply(
+        df_gov["max"] = df_gov["Range"].apply(
             lambda x: x.split("-")[1].replace(",", "").strip().strip("$")
             if "-" in x
             else x.strip("$").replace(",", "")
         )
 
-        df_congress["lower"] = df_congress[["min", "max", "Transaction"]].apply(
+        df_gov["lower"] = df_gov[["min", "max", "Transaction"]].apply(
             lambda x: float(x["min"])
             if x["Transaction"] == "Purchase"
             else -float(x["max"]),
             axis=1,
         )
-        df_congress["upper"] = df_congress[["min", "max", "Transaction"]].apply(
+        df_gov["upper"] = df_gov[["min", "max", "Transaction"]].apply(
             lambda x: float(x["max"])
             if x["Transaction"] == "Purchase"
             else -float(x["min"]),
             axis=1,
         )
 
-        df_congress = df_congress.sort_values("TransactionDate", ascending=True)
+        df_gov = df_gov.sort_values("TransactionDate", ascending=True)
 
         plt.figure(figsize=plot_autoscale(), dpi=PLOT_DPI)
 
-        df_congress.groupby("Ticker")["upper"].sum().sort_values(ascending=False).head(
+        df_gov.groupby("Ticker")["upper"].sum().sort_values(ascending=False).head(
             n=ns_parser.top_num
         ).plot(kind="bar", rot=0)
         plt.ylabel("Amount [$]")
@@ -209,20 +220,20 @@ def buy_congress(other_args: List[str]):
         print(e, "\n")
 
 
-def sell_congress(other_args: List[str]):
-    """Top sell congress trading
+def sell_government(other_args: List[str], type: str):
+    """Top sell government trading
 
     Parameters
     ----------
     other_args : List[str]
         Command line arguments to be processed with argparse
+    type: str
+        Type of government data between: congress, senate and house
     """
     parser = argparse.ArgumentParser(
         add_help=False,
-        prog="sell_congress",
-        description="""
-            Top sell congress trading. [Source: www.quiverquant.com]
-        """,
+        prog="sell_" + type,
+        description=f"Top sell {type} trading. [Source: www.quiverquant.com]",
     )
     parser.add_argument(
         "-p",
@@ -248,49 +259,49 @@ def sell_congress(other_args: List[str]):
         if not ns_parser:
             return
 
-        df_congress = quiverquant_model.get_congress_trading()
+        df_gov = quiverquant_model.get_government_trading(type)
 
-        if df_congress.empty:
-            print("No congress trading data found\n")
+        if df_gov.empty:
+            print(f"No {type} trading data found\n")
             return
 
-        df_congress = df_congress.sort_values("TransactionDate", ascending=False)
+        df_gov = df_gov.sort_values("TransactionDate", ascending=False)
 
         start_date = datetime.now() - timedelta(
             days=ns_parser.past_transactions_months * 30
         )
 
-        df_congress["TransactionDate"] = pd.to_datetime(df_congress["TransactionDate"])
+        df_gov["TransactionDate"] = pd.to_datetime(df_gov["TransactionDate"])
 
-        df_congress = df_congress[df_congress["TransactionDate"] > start_date].dropna()
+        df_gov = df_gov[df_gov["TransactionDate"] > start_date].dropna()
 
-        df_congress["min"] = df_congress["Range"].apply(
+        df_gov["min"] = df_gov["Range"].apply(
             lambda x: x.split("-")[0].strip("$").replace(",", "").strip()
         )
-        df_congress["max"] = df_congress["Range"].apply(
+        df_gov["max"] = df_gov["Range"].apply(
             lambda x: x.split("-")[1].replace(",", "").strip().strip("$")
             if "-" in x
             else x.strip("$").replace(",", "")
         )
 
-        df_congress["lower"] = df_congress[["min", "max", "Transaction"]].apply(
+        df_gov["lower"] = df_gov[["min", "max", "Transaction"]].apply(
             lambda x: float(x["min"])
             if x["Transaction"] == "Purchase"
             else -float(x["max"]),
             axis=1,
         )
-        df_congress["upper"] = df_congress[["min", "max", "Transaction"]].apply(
+        df_gov["upper"] = df_gov[["min", "max", "Transaction"]].apply(
             lambda x: float(x["max"])
             if x["Transaction"] == "Purchase"
             else -float(x["min"]),
             axis=1,
         )
 
-        df_congress = df_congress.sort_values("TransactionDate", ascending=True)
+        df_gov = df_gov.sort_values("TransactionDate", ascending=True)
 
         plt.figure(figsize=plot_autoscale(), dpi=PLOT_DPI)
 
-        df_congress.groupby("Ticker")["lower"].sum().sort_values().abs().head(
+        df_gov.groupby("Ticker")["lower"].sum().sort_values().abs().head(
             n=ns_parser.top_num
         ).plot(kind="bar", rot=0)
         plt.ylabel("Amount [$]")
@@ -310,29 +321,34 @@ def sell_congress(other_args: List[str]):
         print(e, "\n")
 
 
-def plot_congress(congress: pd.DataFrame, ticker: str):
-    """Plot congress trading
+def plot_government(government: pd.DataFrame, ticker: str, type: str):
+    """Plot government trading
 
     Parameters
     ----------
     other_args : List[str]
         Command line arguments to be processed with argparse
     ticker: str
-        Ticker to plot congress trading
+        Ticker to plot government trading
+    type: str
+        Type of government data between: congress, senate and house
     """
     plt.figure(figsize=plot_autoscale(), dpi=PLOT_DPI)
 
     plt.gca().fill_between(
-        congress["TransactionDate"].unique(),
-        congress.groupby("TransactionDate")["lower"].sum().values / 1000,
-        congress.groupby("TransactionDate")["upper"].sum().values / 1000,
+        government["TransactionDate"].unique(),
+        government.groupby("TransactionDate")["lower"].sum().values / 1000,
+        government.groupby("TransactionDate")["upper"].sum().values / 1000,
     )
 
     plt.xlim(
-        [congress["TransactionDate"].values[0], congress["TransactionDate"].values[-1]]
+        [
+            government["TransactionDate"].values[0],
+            government["TransactionDate"].values[-1],
+        ]
     )
     plt.grid()
-    plt.title(f"Congress trading on {ticker}")
+    plt.title(f"{type.capitalize()} trading on {ticker}")
     plt.xlabel("Date")
     plt.ylabel("Amount [1k $]")
     plt.gca().xaxis.set_major_formatter(mdates.DateFormatter("%Y/%m/%d"))
@@ -344,8 +360,8 @@ def plot_congress(congress: pd.DataFrame, ticker: str):
     plt.show()
 
 
-def congress(other_args: List[str], ticker: str):
-    """Congress trading
+def government(other_args: List[str], ticker: str, type: str):
+    """Government trading
 
     Parameters
     ----------
@@ -353,13 +369,13 @@ def congress(other_args: List[str], ticker: str):
         Command line arguments to be processed with argparse
     ticker: str
         Ticker to get congress trading data from
+    type: str
+        Type of government data between: congress, senate and house
     """
     parser = argparse.ArgumentParser(
         add_help=False,
-        prog="congress",
-        description="""
-            Congress trading. [Source: www.quiverquant.com]
-        """,
+        prog=type,
+        description=f"{type} trading. [Source: www.quiverquant.com]",
     )
     parser.add_argument(
         "-p",
@@ -381,47 +397,47 @@ def congress(other_args: List[str], ticker: str):
         if not ns_parser:
             return
 
-        df_congress = quiverquant_model.get_congress_trading(ticker)
+        df_gov = quiverquant_model.get_government_trading(type, ticker)
 
-        if df_congress.empty:
-            print("No congress trading data found\n")
+        if df_gov.empty:
+            print(f"No {type} trading data found\n")
             return
 
-        df_congress = df_congress.sort_values("TransactionDate", ascending=False)
+        df_gov = df_gov.sort_values("TransactionDate", ascending=False)
 
         start_date = datetime.now() - timedelta(
             days=ns_parser.past_transactions_months * 30
         )
 
-        df_congress["TransactionDate"] = pd.to_datetime(df_congress["TransactionDate"])
+        df_gov["TransactionDate"] = pd.to_datetime(df_gov["TransactionDate"])
 
-        df_congress = df_congress[df_congress["TransactionDate"] > start_date]
+        df_gov = df_gov[df_gov["TransactionDate"] > start_date]
 
-        df_congress["min"] = df_congress["Range"].apply(
+        df_gov["min"] = df_gov["Range"].apply(
             lambda x: x.split("-")[0].strip("$").replace(",", "").strip()
         )
-        df_congress["max"] = df_congress["Range"].apply(
+        df_gov["max"] = df_gov["Range"].apply(
             lambda x: x.split("-")[1].replace(",", "").strip().strip("$")
             if "-" in x
             else x.strip("$").replace(",", "")
         )
 
-        df_congress["lower"] = df_congress[["min", "max", "Transaction"]].apply(
+        df_gov["lower"] = df_gov[["min", "max", "Transaction"]].apply(
             lambda x: int(x["min"])
             if x["Transaction"] == "Purchase"
             else -int(x["max"]),
             axis=1,
         )
-        df_congress["upper"] = df_congress[["min", "max", "Transaction"]].apply(
+        df_gov["upper"] = df_gov[["min", "max", "Transaction"]].apply(
             lambda x: int(x["max"])
             if x["Transaction"] == "Purchase"
             else -int(x["min"]),
             axis=1,
         )
 
-        df_congress = df_congress.sort_values("TransactionDate", ascending=True)
+        df_gov = df_gov.sort_values("TransactionDate", ascending=True)
 
-        plot_congress(df_congress, ticker)
+        plot_government(df_gov, ticker, type)
 
         print("")
 

--- a/gamestonk_terminal/government/quiverquant_view.py
+++ b/gamestonk_terminal/government/quiverquant_view.py
@@ -460,7 +460,7 @@ def raw_government(other_args: List[str], ticker: str, gov_type: str):
     parser = argparse.ArgumentParser(
         add_help=False,
         prog=gov_type,
-        description=f"{gov_type} trading. [Source: www.quiverquant.com]",
+        description=f"Raw {gov_type} trading. [Source: www.quiverquant.com]",
     )
     parser.add_argument(
         "-p",
@@ -502,7 +502,11 @@ def raw_government(other_args: List[str], ticker: str, gov_type: str):
             df_gov["TransactionDate"].isin(
                 df_gov["TransactionDate"].unique()[: ns_parser.past_transactions_days]
             )
-        ]
+        ].rename(
+            columns={
+                "TransactionDate": "Transaction Date",
+            }
+        )
 
         print(df_gov.to_string(index=False))
         print("")

--- a/gamestonk_terminal/government/quiverquant_view.py
+++ b/gamestonk_terminal/government/quiverquant_view.py
@@ -1,10 +1,10 @@
 import argparse
 from typing import List
-import pandas as pd
 from datetime import datetime, timedelta
-from gamestonk_terminal.government import quiverquant_model
+import pandas as pd
 from matplotlib import pyplot as plt
 import matplotlib.dates as mdates
+from gamestonk_terminal.government import quiverquant_model
 from gamestonk_terminal.helper_funcs import (
     parse_known_args_and_warn,
     check_positive,
@@ -14,20 +14,20 @@ from gamestonk_terminal.config_plot import PLOT_DPI
 from gamestonk_terminal import feature_flags as gtff
 
 
-def last_government(other_args: List[str], type: str):
+def last_government(other_args: List[str], gov_type: str):
     """Last government trading
 
     Parameters
     ----------
     other_args : List[str]
         Command line arguments to be processed with argparse
-    type: str
+    gov_type: str
         Type of government data between: congress, senate and house
     """
     parser = argparse.ArgumentParser(
         add_help=False,
-        prog="last_" + type,
-        description=f"Last {type} trading. [Source: www.quiverquant.com]",
+        prog="last_" + gov_type,
+        description=f"Last {gov_type} trading. [Source: www.quiverquant.com]",
     )
     parser.add_argument(
         "-p",
@@ -57,10 +57,10 @@ def last_government(other_args: List[str], type: str):
         if not ns_parser:
             return
 
-        df_gov = quiverquant_model.get_government_trading(type)
+        df_gov = quiverquant_model.get_government_trading(gov_type)
 
         if df_gov.empty:
-            print(f"No {type} trading data found\n")
+            print(f"No {gov_type} trading data found\n")
             return
 
         df_gov = df_gov.sort_values("TransactionDate", ascending=False)
@@ -71,7 +71,7 @@ def last_government(other_args: List[str], type: str):
             )
         ]
 
-        if type == "congress":
+        if gov_type == "congress":
             df_gov = df_gov[
                 [
                     "TransactionDate",
@@ -120,20 +120,20 @@ def last_government(other_args: List[str], type: str):
         print(e, "\n")
 
 
-def buy_government(other_args: List[str], type: str):
+def buy_government(other_args: List[str], gov_type: str):
     """Top buy government trading
 
     Parameters
     ----------
     other_args : List[str]
         Command line arguments to be processed with argparse
-    type: str
+    gov_type: str
         Type of government data between: congress, senate and house
     """
     parser = argparse.ArgumentParser(
         add_help=False,
-        prog="buy_" + type,
-        description=f"Top buy {type} trading. [Source: www.quiverquant.com]",
+        prog="buy_" + gov_type,
+        description=f"Top buy {gov_type} trading. [Source: www.quiverquant.com]",
     )
     parser.add_argument(
         "-p",
@@ -159,10 +159,10 @@ def buy_government(other_args: List[str], type: str):
         if not ns_parser:
             return
 
-        df_gov = quiverquant_model.get_government_trading(type)
+        df_gov = quiverquant_model.get_government_trading(gov_type)
 
         if df_gov.empty:
-            print(f"No {type} trading data found\n")
+            print(f"No {gov_type} trading data found\n")
             return
 
         df_gov = df_gov.sort_values("TransactionDate", ascending=False)
@@ -220,20 +220,20 @@ def buy_government(other_args: List[str], type: str):
         print(e, "\n")
 
 
-def sell_government(other_args: List[str], type: str):
+def sell_government(other_args: List[str], gov_type: str):
     """Top sell government trading
 
     Parameters
     ----------
     other_args : List[str]
         Command line arguments to be processed with argparse
-    type: str
+    gov_type: str
         Type of government data between: congress, senate and house
     """
     parser = argparse.ArgumentParser(
         add_help=False,
-        prog="sell_" + type,
-        description=f"Top sell {type} trading. [Source: www.quiverquant.com]",
+        prog="sell_" + gov_type,
+        description=f"Top sell {gov_type} trading. [Source: www.quiverquant.com]",
     )
     parser.add_argument(
         "-p",
@@ -259,10 +259,10 @@ def sell_government(other_args: List[str], type: str):
         if not ns_parser:
             return
 
-        df_gov = quiverquant_model.get_government_trading(type)
+        df_gov = quiverquant_model.get_government_trading(gov_type)
 
         if df_gov.empty:
-            print(f"No {type} trading data found\n")
+            print(f"No {gov_type} trading data found\n")
             return
 
         df_gov = df_gov.sort_values("TransactionDate", ascending=False)
@@ -321,7 +321,7 @@ def sell_government(other_args: List[str], type: str):
         print(e, "\n")
 
 
-def plot_government(government: pd.DataFrame, ticker: str, type: str):
+def plot_government(government: pd.DataFrame, ticker: str, gov_type: str):
     """Plot government trading
 
     Parameters
@@ -330,7 +330,7 @@ def plot_government(government: pd.DataFrame, ticker: str, type: str):
         Command line arguments to be processed with argparse
     ticker: str
         Ticker to plot government trading
-    type: str
+    gov_type: str
         Type of government data between: congress, senate and house
     """
     plt.figure(figsize=plot_autoscale(), dpi=PLOT_DPI)
@@ -348,7 +348,7 @@ def plot_government(government: pd.DataFrame, ticker: str, type: str):
         ]
     )
     plt.grid()
-    plt.title(f"{type.capitalize()} trading on {ticker}")
+    plt.title(f"{gov_type.capitalize()} trading on {ticker}")
     plt.xlabel("Date")
     plt.ylabel("Amount [1k $]")
     plt.gca().xaxis.set_major_formatter(mdates.DateFormatter("%Y/%m/%d"))
@@ -360,7 +360,7 @@ def plot_government(government: pd.DataFrame, ticker: str, type: str):
     plt.show()
 
 
-def government(other_args: List[str], ticker: str, type: str):
+def government_trading(other_args: List[str], ticker: str, gov_type: str):
     """Government trading
 
     Parameters
@@ -369,13 +369,13 @@ def government(other_args: List[str], ticker: str, type: str):
         Command line arguments to be processed with argparse
     ticker: str
         Ticker to get congress trading data from
-    type: str
+    gov_type: str
         Type of government data between: congress, senate and house
     """
     parser = argparse.ArgumentParser(
         add_help=False,
-        prog=type,
-        description=f"{type} trading. [Source: www.quiverquant.com]",
+        prog=gov_type,
+        description=f"{gov_type} trading. [Source: www.quiverquant.com]",
     )
     parser.add_argument(
         "-p",
@@ -397,10 +397,10 @@ def government(other_args: List[str], ticker: str, type: str):
         if not ns_parser:
             return
 
-        df_gov = quiverquant_model.get_government_trading(type, ticker)
+        df_gov = quiverquant_model.get_government_trading(gov_type, ticker)
 
         if df_gov.empty:
-            print(f"No {type} trading data found\n")
+            print(f"No {gov_type} trading data found\n")
             return
 
         df_gov = df_gov.sort_values("TransactionDate", ascending=False)
@@ -437,8 +437,74 @@ def government(other_args: List[str], ticker: str, type: str):
 
         df_gov = df_gov.sort_values("TransactionDate", ascending=True)
 
-        plot_government(df_gov, ticker, type)
+        plot_government(df_gov, ticker, gov_type)
 
+        print("")
+
+    except Exception as e:
+        print(e, "\n")
+
+
+def raw_government(other_args: List[str], ticker: str, gov_type: str):
+    """Raw government trading
+
+    Parameters
+    ----------
+    other_args : List[str]
+        Command line arguments to be processed with argparse
+    ticker: str
+        Ticker to get congress trading data from
+    gov_type: str
+        Type of government data between: congress, senate and house
+    """
+    parser = argparse.ArgumentParser(
+        add_help=False,
+        prog=gov_type,
+        description=f"{gov_type} trading. [Source: www.quiverquant.com]",
+    )
+    parser.add_argument(
+        "-p",
+        "--past_transactions_days",
+        action="store",
+        dest="past_transactions_days",
+        type=check_positive,
+        default=10,
+        help="Past transaction days",
+    )
+
+    try:
+
+        if other_args:
+            if "-" not in other_args[0]:
+                other_args.insert(0, "-p")
+
+        ns_parser = parse_known_args_and_warn(parser, other_args)
+        if not ns_parser:
+            return
+
+        df_gov = quiverquant_model.get_government_trading(gov_type, ticker)
+
+        if df_gov.empty:
+            print(f"No {gov_type} trading data found\n")
+            return
+
+        df_gov = df_gov.sort_values("TransactionDate", ascending=False)
+        if gov_type == "congress":
+            df_gov = df_gov[
+                ["TransactionDate", "Representative", "House", "Transaction", "Range"]
+            ]
+        else:
+            df_gov = df_gov[
+                ["TransactionDate", "Representative", "Transaction", "Range"]
+            ]
+
+        df_gov = df_gov[
+            df_gov["TransactionDate"].isin(
+                df_gov["TransactionDate"].unique()[: ns_parser.past_transactions_days]
+            )
+        ]
+
+        print(df_gov.to_string(index=False))
         print("")
 
     except Exception as e:

--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -59,7 +59,7 @@ def plot_view_stock(df, symbol):
     plt.ylabel("Volume")
     _ = axVolume.twinx()
     plt.plot(df.index, df.iloc[:, :-1])
-    plt.title(symbol + " (Time Series)")
+    plt.title(symbol.upper() + " (Time Series)")
     plt.xlim(df.index[0], df.index[-1])
     plt.xlabel("Time")
     plt.ylabel("Share Price ($)")

--- a/gamestonk_terminal/main_helper.py
+++ b/gamestonk_terminal/main_helper.py
@@ -455,7 +455,35 @@ def view(l_args, s_ticker, s_start, s_interval, df_stock):
         return
 
     # Update values:
-    s_ticker = ns_parser.s_ticker
+    if ns_parser.s_ticker != s_ticker:
+        if ns_parser.n_interval > 0:
+            s_ticker, s_start, s_interval, df_stock = load(
+                [
+                    "-t",
+                    ns_parser.s_ticker,
+                    "-s",
+                    ns_parser.s_start_date.strftime("%Y-%m-%d"),
+                    "-i",
+                    ns_parser.n_interval,
+                ],
+                s_ticker,
+                s_start,
+                s_interval,
+                df_stock,
+            )
+        else:
+            s_ticker, s_start, s_interval, df_stock = load(
+                [
+                    "-t",
+                    ns_parser.s_ticker,
+                    "-s",
+                    ns_parser.s_start_date.strftime("%Y-%m-%d"),
+                ],
+                s_ticker,
+                s_start,
+                s_interval,
+                df_stock,
+            )
 
     # A new interval intraday period was given
     if ns_parser.n_interval != 0:

--- a/gamestonk_terminal/screener/finviz_view.py
+++ b/gamestonk_terminal/screener/finviz_view.py
@@ -5,9 +5,8 @@ import argparse
 from typing import List
 import os
 import configparser
-import pandas as pd
 from datetime import datetime
-from gamestonk_terminal.papermill import due_diligence_view
+import pandas as pd
 from finvizfinance.screener import (
     technical,
     overview,
@@ -16,10 +15,13 @@ from finvizfinance.screener import (
     ownership,
     performance,
 )
+from gamestonk_terminal.papermill import due_diligence_view
 from gamestonk_terminal.helper_funcs import (
     parse_known_args_and_warn,
     check_positive,
 )
+
+presets_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "presets/")
 
 d_signals = {
     "top_gainers": "Top Gainers",
@@ -83,7 +85,7 @@ def get_screener_data(
     """
     preset_filter = configparser.RawConfigParser()
     preset_filter.optionxform = str  # type: ignore
-    preset_filter.read("gamestonk_terminal/screener/presets/" + preset_loaded + ".ini")
+    preset_filter.read(presets_path + preset_loaded + ".ini")
 
     d_general = preset_filter["General"]
     d_filters = {
@@ -137,7 +139,7 @@ def get_screener_data(
     return df_screen
 
 
-def screener(other_args: List[str], loaded_preset: str, data_type: str):
+def screener(other_args: List[str], loaded_preset: str, data_type: str) -> List[str]:
     """Screener
 
     Parameters
@@ -148,6 +150,11 @@ def screener(other_args: List[str], loaded_preset: str, data_type: str):
         Loaded preset filter
     data_type : str
         Data type string between: overview, valuation, financial, ownership, performance, technical
+
+    Returns
+    -------
+    List[str]
+        List of stocks that meet preset criteria
     """
     parser = argparse.ArgumentParser(
         add_help=False,
@@ -169,7 +176,7 @@ def screener(other_args: List[str], loaded_preset: str, data_type: str):
         help="Filter presets",
         choices=[
             preset.split(".")[0]
-            for preset in os.listdir("gamestonk_terminal/screener/presets")
+            for preset in os.listdir(presets_path)
             if preset[-4:] == ".ini"
         ],
     )
@@ -218,7 +225,7 @@ def screener(other_args: List[str], loaded_preset: str, data_type: str):
     try:
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if not ns_parser:
-            return
+            return []
 
         df_screen = get_screener_data(
             ns_parser.preset,
@@ -245,9 +252,9 @@ def screener(other_args: List[str], loaded_preset: str, data_type: str):
                     ticker = [df_screen.iat[i, 0]]
                     due_diligence_view.due_diligence(ticker, show=False)
             return list(df_screen["Ticker"].values)
-        else:
-            print("")
-            return []
+
+        print("")
+        return []
 
     except Exception as e:
         print(e)

--- a/gamestonk_terminal/screener/screener_controller.py
+++ b/gamestonk_terminal/screener/screener_controller.py
@@ -6,16 +6,18 @@ import argparse
 import configparser
 from typing import List
 import matplotlib.pyplot as plt
-from gamestonk_terminal import feature_flags as gtff
+from prompt_toolkit.completion import NestedCompleter
 from gamestonk_terminal.helper_funcs import get_flair
 from gamestonk_terminal.menu import session
-from prompt_toolkit.completion import NestedCompleter
+from gamestonk_terminal import feature_flags as gtff
 from gamestonk_terminal.helper_funcs import (
     parse_known_args_and_warn,
 )
 from gamestonk_terminal.screener import finviz_view
 from gamestonk_terminal.screener import yahoo_finance_view
 from gamestonk_terminal.portfolio_optimization import po_controller
+
+presets_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "presets/")
 
 
 class ScreenerController:
@@ -49,7 +51,6 @@ class ScreenerController:
             choices=self.CHOICES,
         )
 
-    @staticmethod
     def print_help(self):
         """Print help"""
 
@@ -97,7 +98,7 @@ class ScreenerController:
             default="",
             choices=[
                 preset.split(".")[0]
-                for preset in os.listdir("gamestonk_terminal/screener/presets")
+                for preset in os.listdir(presets_path)
                 if preset[-4:] == ".ini"
             ],
         )
@@ -113,9 +114,7 @@ class ScreenerController:
             if ns_parser.preset:
                 preset_filter = configparser.RawConfigParser()
                 preset_filter.optionxform = str  # type: ignore
-                preset_filter.read(
-                    "gamestonk_terminal/screener/presets/" + ns_parser.preset + ".ini"
-                )
+                preset_filter.read(presets_path + ns_parser.preset + ".ini")
 
                 filters_headers = ["General", "Descriptive", "Fundamental", "Technical"]
 
@@ -133,18 +132,18 @@ class ScreenerController:
             else:
                 presets = [
                     preset.split(".")[0]
-                    for preset in os.listdir("gamestonk_terminal/screener/presets")
+                    for preset in os.listdir(presets_path)
                     if preset[-4:] == ".ini"
                 ]
 
                 for preset in presets:
                     with open(
-                        "gamestonk_terminal/screener/presets/" + preset + ".ini",
+                        presets_path + preset + ".ini",
                         encoding="utf8",
                     ) as f:
                         description = ""
                         for line in f:
-                            if "[General]" == line.strip():
+                            if line.strip() == "[General]":
                                 break
                             description += line.strip()
                     print(f"\nPRESET: {preset}")
@@ -154,7 +153,6 @@ class ScreenerController:
         except Exception as e:
             print(e)
 
-    @staticmethod
     def set_preset(self, other_args: List[str]):
         """Set preset"""
         parser = argparse.ArgumentParser(
@@ -172,7 +170,7 @@ class ScreenerController:
             help="Filter presets",
             choices=[
                 preset.split(".")[0]
-                for preset in os.listdir("gamestonk_terminal/screener/presets")
+                for preset in os.listdir(presets_path)
                 if preset[-4:] == ".ini"
             ],
         )
@@ -212,7 +210,7 @@ class ScreenerController:
 
     def call_help(self, _):
         """Process Help command"""
-        self.print_help(self)
+        self.print_help()
 
     def call_q(self, _):
         """Process Q command - quit the menu"""
@@ -228,7 +226,7 @@ class ScreenerController:
 
     def call_set(self, other_args: List[str]):
         """Process overview command"""
-        self.set_preset(self, other_args)
+        self.set_preset(other_args)
 
     def call_historical(self, other_args: List[str]):
         """Process historical command"""
@@ -264,7 +262,7 @@ class ScreenerController:
         """Process signals command"""
         finviz_view.view_signals(other_args)
 
-    def call_po(self, other_args: List[str]):
+    def call_po(self, _):
         """Call the portfolio optimization menu with selected tickers"""
         return po_controller.menu(self.screen_tickers)
 

--- a/gamestonk_terminal/screener/yahoo_finance_view.py
+++ b/gamestonk_terminal/screener/yahoo_finance_view.py
@@ -1,10 +1,11 @@
+import os
 import argparse
 from typing import List
 import random
-from pandas.plotting import register_matplotlib_converters
-import matplotlib.pyplot as plt
 import datetime
 import configparser
+from pandas.plotting import register_matplotlib_converters
+import matplotlib.pyplot as plt
 import yfinance as yf
 from finvizfinance.screener import ticker
 from gamestonk_terminal.screener import finviz_view
@@ -18,6 +19,8 @@ from gamestonk_terminal.config_plot import PLOT_DPI
 
 register_matplotlib_converters()
 
+presets_path = os.path.join(os.path.abspath(os.path.dirname(__file__)), "presets/")
+
 d_candle_types = {
     "o": "Open",
     "h": "High",
@@ -28,18 +31,12 @@ d_candle_types = {
 
 
 def check_one_of_ohlca(type_candles: str) -> str:
-    if (
-        type_candles == "o"
-        or type_candles == "h"
-        or type_candles == "l"
-        or type_candles == "c"
-        or type_candles == "a"
-    ):
+    if type_candles in ("o", "h", "l", "c", "a"):
         return type_candles
     raise argparse.ArgumentTypeError("The type of candles specified is not recognized")
 
 
-def historical(other_args: List[str], preset_loaded: str):
+def historical(other_args: List[str], preset_loaded: str) -> List[str]:
     """View historical price of stocks that meet preset
 
     Parameters
@@ -48,6 +45,11 @@ def historical(other_args: List[str], preset_loaded: str):
         Command line arguments to be processed with argparse
     ticker : str
         Loaded preset filter
+
+    Returns
+    -------
+    List[str]
+        List of stocks that meet preset criteria
     """
     parser = argparse.ArgumentParser(
         add_help=False,
@@ -85,13 +87,11 @@ def historical(other_args: List[str], preset_loaded: str):
     try:
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if not ns_parser:
-            return
+            return list()
 
         preset_filter = configparser.RawConfigParser()
         preset_filter.optionxform = str  # type: ignore
-        preset_filter.read(
-            "gamestonk_terminal/screener/presets/" + preset_loaded + ".ini"
-        )
+        preset_filter.read(presets_path + preset_loaded + ".ini")
 
         d_general = preset_filter["General"]
         d_filters = {

--- a/terminal.py
+++ b/terminal.py
@@ -114,7 +114,9 @@ def main():
 
     try:
         if os.name == "nt":
+            # pylint: disable=E1101
             sys.stdin.reconfigure(encoding="utf-8")
+            # pylint: disable=E1101
             sys.stdout.reconfigure(encoding="utf-8")
     except Exception as e:
         print(e, "\n")

--- a/terminal.py
+++ b/terminal.py
@@ -8,6 +8,7 @@ import subprocess
 from datetime import datetime, timedelta
 import pandas as pd
 import yfinance as yf
+from matplotlib import pyplot as plt
 from alpha_vantage.timeseries import TimeSeries
 from prompt_toolkit.completion import NestedCompleter
 
@@ -136,6 +137,7 @@ def main():
 
     # Loop forever and ever
     while True:
+
         main_cmd = False
         if should_print_help:
             print_help(s_ticker, s_start, s_interval, b_is_stock_market_open())
@@ -154,6 +156,8 @@ def main():
             as_input = session.prompt(f"{get_flair()}> ", completer=completer)
         else:
             as_input = input(f"{get_flair()}> ")
+
+        plt.close("all")
 
         # Is command empty
         if not as_input:
@@ -208,15 +212,7 @@ def main():
             main_cmd = True
 
         elif ns_known_args.opt == "view":
-
-            if s_ticker:
-                view(l_args, s_ticker, s_start, s_interval, df_stock)
-
-            else:
-                print(
-                    "No ticker selected. Use 'load ticker' to load the ticker you want to look at.",
-                    "\n",
-                )
+            view(l_args, s_ticker, s_start, s_interval, df_stock)
             main_cmd = True
 
         elif ns_known_args.opt == "export":


### PR DESCRIPTION
This PR does:
* Fix absolute path to access screeners. This way the user can run terminal from anywhere, as presets folder is assessed relatively.
* Add Senate and House trading, and not only Congress.
* Add possibility to saw last days of transactions for a particular ticker for senate, house, and both (congress).
* Fix view command for subsequent tickers