### PR TITLE
Make `gst` executable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,12 @@ name = "GamestonkTerminal"
 version = "0.1.0"
 description = ""
 authors = ["Didier Rodrigues Lopes"]
+packages = [
+    { include = "gamestonk_terminal" },
+]
+
+[tool.poetry.scripts]
+gst = 'terminal:main'
 
 [tool.poetry.dependencies]
 python = "^3.6.8"


### PR DESCRIPTION
Hi, this let run the command `gst` from anywhere in the `virtualenv` instead of having to call `terminal.py`