### PR TITLE
Add How to add preset README sections

### DIFF
--- a/gamestonk_terminal/main_helper.py
+++ b/gamestonk_terminal/main_helper.py
@@ -730,6 +730,7 @@ def about_us():
         f"{Fore.YELLOW}Partnerships:{Style.RESET_ALL}\n"
         f"{Fore.CYAN}FinBrain: {Style.RESET_ALL}https://finbrain.tech\n"
         f"{Fore.CYAN}Quiver Quantitative: {Style.RESET_ALL}https://www.quiverquant.com\n"
+        f"{Fore.CYAN}Ops.Syncretism: {Style.RESET_ALL}https://ops.syncretism.io/api.html\n"
         f"\n{Fore.RED}"
         "DISCLAIMER: Trading in financial instruments involves high risks including the risk of losing some, "
         "or all, of your investment amount, and may not be suitable for all investors. Before deciding to trade in "

--- a/gamestonk_terminal/options/presets/README.md
+++ b/gamestonk_terminal/options/presets/README.md
@@ -1,6 +1,32 @@
 # PRESETS
 
+* [How to add presets](#how-to-add-presets)
 * [template](#template)
+
+---
+
+## How to add Presets
+
+1. Go to the folder GamestonkTerminal/gamestonk_terminal/options/presets. 
+
+2. There should be a `README.md` file and multiple `.ini` files. One of these `.ini` files should be named `template.ini`.
+
+<img width="470" alt="Captura de ecrã 2021-06-28, às 22 00 14" src="https://user-images.githubusercontent.com/25267873/123706416-2be7be80-d860-11eb-9255-58787e264f49.png">
+
+3. Copy the `template.ini` file and paste it in the same directory.
+4. Rename that file to something you find meaningful, e.g. `my_own_filter.ini`.
+
+<img width="450" alt="Captura de ecrã 2021-06-28, às 22 04 27" src="https://user-images.githubusercontent.com/25267873/123706424-2db18200-d860-11eb-9523-e4647a073645.png">
+
+5. Open the file you just renamed (e.g. `my_own_filter.ini`), and set the parameters you want to filter. 
+
+6. It may be useful to play with the main source https://ops.syncretism.io since you can tweak these and understand how they influence the outcome of the filtered stocks.
+
+<img width="472" alt="Captura de ecrã 2021-06-28, às 22 08 16" src="https://user-images.githubusercontent.com/25267873/123706427-2e4a1880-d860-11eb-8523-24654013d3e4.png">
+
+<img width="1218" alt="Captura de ecrã 2021-06-28, às 22 10 25" src="https://user-images.githubusercontent.com/25267873/123706431-2f7b4580-d860-11eb-9074-efa96278d241.png">
+
+
 
 ---
 

--- a/gamestonk_terminal/options/presets/README.md
+++ b/gamestonk_terminal/options/presets/README.md
@@ -26,15 +26,19 @@
 
 <img width="1036" alt="Captura de ecrã 2021-06-28, às 22 53 13" src="https://user-images.githubusercontent.com/25267873/123708702-c85f9000-d863-11eb-835e-13ea07e45e04.png">
 
-Then you can play with it on the terminal as shown:
+7. Update the Author and Description name. E.g.
+
+<img width="462" alt="Captura de ecrã 2021-06-28, às 23 26 26" src="https://user-images.githubusercontent.com/25267873/123711451-6b1a0d80-d868-11eb-9887-3389bbff6514.png">
+
+8. Start the terminal, and go to the `>   op` menu. In there, you can play with it on the terminal as shown:
 * **disp**: Allows to see the screeners available. I.e. all `.ini` files in presets folder.
 * **disp <selected_preset>**: Allows to see the specific parameters set for the preset selected.
 * **scr <selected_preset>**: Allows to show stocks that are filtered using the selected preset.
   * Note: As default, if the user does **scr** this will use the `template.ini` file. So, the user can do some tests with teaking of parameters on the `template.ini` file.
 
-<img width="1218" alt="Captura de ecrã 2021-06-28, às 22 10 25" src="https://user-images.githubusercontent.com/25267873/123706431-2f7b4580-d860-11eb-9074-efa96278d241.png">
+<img width="1220" alt="Captura de ecrã 2021-06-28, às 23 28 36" src="https://user-images.githubusercontent.com/25267873/123711622-aa485e80-d868-11eb-8c9f-ed9e6453632b.png">
 
-7. Share with other Apes. You can do so by either creating yourself a Pull Request with this change, or asking a dev (e.g. @Sexy_Year) on our discord server to add it for you.
+9. Share with other Apes. You can do so by either creating yourself a Pull Request with this change, or asking a dev (e.g. @Sexy_Year) on our discord server to add it for you.
 
 ---
 

--- a/gamestonk_terminal/options/presets/README.md
+++ b/gamestonk_terminal/options/presets/README.md
@@ -34,6 +34,7 @@ Then you can play with it on the terminal as shown:
 
 <img width="1218" alt="Captura de ecrã 2021-06-28, às 22 10 25" src="https://user-images.githubusercontent.com/25267873/123706431-2f7b4580-d860-11eb-9074-efa96278d241.png">
 
+7. Share with other Apes. You can do so by either creating yourself a Pull Request with this change, or asking a dev (e.g. @Sexy_Year) on our discord server to add it for you.
 
 ---
 

--- a/gamestonk_terminal/options/presets/README.md
+++ b/gamestonk_terminal/options/presets/README.md
@@ -20,12 +20,19 @@
 
 5. Open the file you just renamed (e.g. `my_own_filter.ini`), and set the parameters you want to filter. 
 
-6. It may be useful to play with the main source https://ops.syncretism.io since you can tweak these and understand how they influence the outcome of the filtered stocks.
-
 <img width="472" alt="Captura de ecrã 2021-06-28, às 22 08 16" src="https://user-images.githubusercontent.com/25267873/123706427-2e4a1880-d860-11eb-8523-24654013d3e4.png">
 
-<img width="1218" alt="Captura de ecrã 2021-06-28, às 22 10 25" src="https://user-images.githubusercontent.com/25267873/123706431-2f7b4580-d860-11eb-9074-efa96278d241.png">
+6. It may be useful to play with the main source https://ops.syncretism.io since you can tweak these and understand how they influence the outcome of the filtered stocks. 
 
+<img width="1036" alt="Captura de ecrã 2021-06-28, às 22 53 13" src="https://user-images.githubusercontent.com/25267873/123708702-c85f9000-d863-11eb-835e-13ea07e45e04.png">
+
+Then you can play with it on the terminal as shown:
+* **disp**: Allows to see the screeners available. I.e. all `.ini` files in presets folder.
+* **disp <selected_preset>**: Allows to see the specific parameters set for the preset selected.
+* **scr <selected_preset>**: Allows to show stocks that are filtered using the selected preset.
+  * Note: As default, if the user does **scr** this will use the `template.ini` file. So, the user can do some tests with teaking of parameters on the `template.ini` file.
+
+<img width="1218" alt="Captura de ecrã 2021-06-28, às 22 10 25" src="https://user-images.githubusercontent.com/25267873/123706431-2f7b4580-d860-11eb-9074-efa96278d241.png">
 
 
 ---

--- a/gamestonk_terminal/options/presets/template.ini
+++ b/gamestonk_terminal/options/presets/template.ini
@@ -14,6 +14,12 @@ min-diff =
 # max-diff [int]: maximum difference in percentage between strike and stock price.
 max-diff =
 
+# itm [bool]: select in the money options.
+itm = true
+
+# otm [bool]: select out of the money options.
+otm = true
+
 # min-ask-bid [float]: minimum spread between bid and ask.
 min-ask-bid =
 

--- a/gamestonk_terminal/options/presets/template.ini
+++ b/gamestonk_terminal/options/presets/template.ini
@@ -2,98 +2,105 @@
 # Description: This is just a sample. The user that adds the preset can add a description for what type of stocks these filters are being used.
 [FILTER]
 
-# tickers [string]
-# - a list of space or comma separated tickers to restrict or exclude them from the query.
+# tickers [string]: a list of space or comma separated tickers to restrict or exclude them from the query.
 tickers =
 
-# exclude [true|false]
-# - if true, then tickers are excluded. If false, the search is restricted to these tickers.
+# exclude [true|false]: if true, then tickers are excluded. If false, the search is restricted to these tickers.
 exclude =
 
-# min-diff [int]
-# - minimum difference in percentage between strike and stock price.
+# min-diff [int]: minimum difference in percentage between strike and stock price.
 min-diff =
 
-# max-diff [int]
-# - maximum difference in percentage between strike and stock price.
+# max-diff [int]: maximum difference in percentage between strike and stock price.
 max-diff =
 
-# min-ask-bid [float]
-# - minimum spread between bid and ask.
+# min-ask-bid [float]: minimum spread between bid and ask.
 min-ask-bid =
 
-# max-ask-bid [float]
-# - maximum spread between bid and ask.
+# max-ask-bid [float]: maximum spread between bid and ask.
 max-ask-bid =
 
-# min-exp [int]
-# - minimum days until expiration.
+# min-exp [int]: minimum days until expiration.
 min-exp =
 
-# max-exp [int]
-# - maximum days until expiration.
+# max-exp [int]: maximum days until expiration.
 max-exp =
 
-# min-price [float]
-# - minimum option premium.
+# min-price [float]: minimum option premium.
 min-price =
 
-# max-price [float]
-# - maximum option premium.
+# max-price [float]: maximum option premium.
 max-price =
 
-# calls [true|false]
-# - select call options.
+# calls [true|false]: select call options.
 calls =
 
-# puts [true|false]
-# - select put options.
+# puts [true|false]: select put options.
 puts =
 
-# stock [true|false]
-# - select normal stocks.
+# stock [true|false]: select normal stocks.
 stock =
 
-# etf [true|false]
-# - select etf options.
+# etf [true|false]: select etf options.
 etf =
 
-# min-sto [float]
-# - minimum option price / stock price ratio.
+# min-sto [float]: minimum option price / stock price ratio.
 min-sto =
 
-# max-sto [float]
-# - maximum option price / stock price ratio.
+# max-sto [float]: maximum option price / stock price ratio.
 max-sto =
 
-# min-pso [float]
-# - minimum premium / strike price ratio.
-min-pso =
+# min-yield [float]: minimum premium / strike price ratio.
+min-yield =
 
-# max-pso [float]
-# - maximum premium / strike price ratio.
-max-pso =
+# max-yield [float]: maximum premium / strike price ratio.
+max-yield =
 
-# min-cap [float]
-# - minimum market capitalization (in billions USD).
+# min-myield [float]: minimum yield per month until expiration date.
+min-myield =
+
+# max-myield [float]: maximum yield per month until expiration date.
+max-myield =
+
+# min-delta [float]: minimum delta greek.
+min-delta =
+
+# max-delta [float]: maximum delta greek.
+max-delta =
+
+# min-gamma [float]: minimum gamma greek.
+min-gamma =
+
+# max-gamma [float]: maximum gamma greek.
+max-gamma =
+
+# min-theta [float]: minimum theta greek.
+min-theta =
+
+# max-theta [float]: maximum theta greek.
+max-theta =
+
+# min-vega [float]: minimum vega greek.
+min-vega =
+
+# max-vega [float]: maximum vega greek.
+max-vega =
+
+# min-cap [float]: minimum market capitalization (in billions USD).
 min-cap =
 
-# max-cap [float]
-# - maximum market capitalization (in billions USD).
+# max-cap [float]: maximum market capitalization (in billions USD).
 max-cap =
 
-# order-by [default: e_desc]
-# - how to order results, possible values:
+# order-by [default: e_desc]: how to order results, possible values:
 #     e_desc, e_asc: expiration, descending / ascending.
 #     iv_desc, iv_asc: implied volatility, descending / ascending.
 #     lp_desc, lp_asc: lastprice, descending / ascending.
 #     md_desc, md_asc: current stock price, descending / ascending.
 order-by =
 
-# limit [int]
-# - number of results (max 50).
+# limit [int]: number of results (max 50).
 limit =
 
-# active [true|false]
-# - if set to true, restricts to options for which volume, open interest, ask, and bid are all > 0.
+# active [true|false]: if set to true, restricts to options for which volume, open interest, ask, and bid are all > 0.
 active =

--- a/gamestonk_terminal/options/syncretism_view.py
+++ b/gamestonk_terminal/options/syncretism_view.py
@@ -80,8 +80,7 @@ def view_available_presets(other_args: List[str]):
                         description += line.strip()
                 print(f"\nPRESET: {preset}")
                 print(description.split("Description: ")[1].replace("#", ""))
-                print("")
-
+            print("")
     except Exception as e:
         print(e)
 

--- a/gamestonk_terminal/screener/presets/README.md
+++ b/gamestonk_terminal/screener/presets/README.md
@@ -18,9 +18,46 @@
 
 ---
 
-1. Go to the folder GamestonkTerminal/gamestonk_terminal/options/presets. 
+## How to add presets
+
+1. Go to the folder GamestonkTerminal/gamestonk_terminal/screener/presets. 
 
 2. There should be a `README.md` file and multiple `.ini` files. One of these `.ini` files should be named `template.ini`.
+
+<img width="449" alt="1" src="https://user-images.githubusercontent.com/25267873/123713241-db765e00-d86b-11eb-9feb-f05f471d9aa5.png">
+
+3. Copy the `template.ini` file and paste it in the same directory.
+4. Rename that file to something you find meaningful, e.g. `my_own_filter.ini`.
+
+<img width="448" alt="2" src="https://user-images.githubusercontent.com/25267873/123713233-da453100-d86b-11eb-853e-9a850cd064d1.png">
+
+5. Open the file you just renamed (e.g. `my_own_filter.ini`), and set the parameters you want to filter. 
+
+<img width="859" alt="3" src="https://user-images.githubusercontent.com/25267873/123713235-da453100-d86b-11eb-9f65-f957f99d5d60.png">
+
+6. It may be useful to play with the main source https://finviz.com/screener.ashx since you can tweak these and understand how they influence the outcome of the filtered stocks. 
+
+<img width="1256" alt="4" src="https://user-images.githubusercontent.com/25267873/123713236-daddc780-d86b-11eb-9faf-2ee58fc304d3.png">
+
+7. Update the Author and Description name. E.g.
+
+<img width="807" alt="5" src="https://user-images.githubusercontent.com/25267873/123713239-db765e00-d86b-11eb-8b58-127205d75894.png">
+
+8. Start the terminal, and go to the `>   scr` menu. In there, you can play with it on the terminal as shown:
+* **view**: Allows to see the screeners available. I.e. all `.ini` files in presets folder.
+<img width="1201" alt="6" src="https://user-images.githubusercontent.com/25267873/123713231-d9ac9a80-d86b-11eb-920a-0959481de143.png">
+
+* **view <selected_preset>**: Allows to see the specific parameters set for the preset selected.
+<img width="443" alt="Captura de ecrã 2021-06-28, às 23 58 35" src="https://user-images.githubusercontent.com/25267873/123713683-d82fa200-d86c-11eb-92ee-bf5ae14d5f12.png">
+
+* **set <selected_preset>**: Allows to set this preset as main filter. See that the help menu will display a different `PRESET: my_own_filter`
+<img width="857" alt="7" src="https://user-images.githubusercontent.com/25267873/123713226-d9140400-d86b-11eb-9a61-bce07b6f580d.png">
+
+* **historical, overview, valuation, financial, ownership, performance, technical** commands will now be performed on tickers that are filtered with the selected preset. Note: Since it is likely that there will be a big range of tickers, we cap it to 10 randomly. So, it is normal if for the same filter the user sees 10 different tickers. If the user wants to see more than 10 tickers, it can select a different limit using `-l` flag.
+
+<img width="1049" alt="8" src="https://user-images.githubusercontent.com/25267873/123713223-d6191380-d86b-11eb-9e50-ac3a32d7922d.png">
+
+9. Share with other Apes. You can do so by either creating yourself a Pull Request with this change, or asking a dev (e.g. @Sexy_Year) on our discord server to add it for you.
 
 ---
 

--- a/gamestonk_terminal/screener/presets/README.md
+++ b/gamestonk_terminal/screener/presets/README.md
@@ -1,5 +1,6 @@
 # PRESETS
 
+* [How to add presets](#how-to-add-presets)
 * [template](#template)
 * [sexy_year](#sexy_year)
 * [buffett_like](#buffett_like)
@@ -14,6 +15,12 @@
 * [rosenwald](#rosenwald)
 * [rosenwald_gtfo](#rosenwald_gtfo)
 * [undervalue](#undervalue)
+
+---
+
+1. Go to the folder GamestonkTerminal/gamestonk_terminal/options/presets. 
+
+2. There should be a `README.md` file and multiple `.ini` files. One of these `.ini` files should be named `template.ini`.
 
 ---
 

--- a/gamestonk_terminal/screener/screener_controller.py
+++ b/gamestonk_terminal/screener/screener_controller.py
@@ -150,7 +150,7 @@ class ScreenerController:
                             description += line.strip()
                     print(f"\nPRESET: {preset}")
                     print(description.split("Description: ")[1].replace("#", ""))
-                    print("")
+                print("")
 
         except Exception as e:
             print(e)


### PR DESCRIPTION
This PR:
* Adds **How to add preset** sections to the **Screener/presets** and **Options/presets** READMEs. 
* Updates Options screener based on Syncretism API update. The owner contacted us on Discord to say he liked the terminal, and let us know about the change and the future data we'll be able to extract from his website: https://ops.syncretism.io
