### PR TITLE
A bunch of bugfixes

### DIFF
--- a/gamestonk_terminal/behavioural_analysis/twitter_view.py
+++ b/gamestonk_terminal/behavioural_analysis/twitter_view.py
@@ -142,6 +142,9 @@ def inference(other_args: List[str], s_ticker: str):
 
         df_tweets = load_analyze_tweets(s_ticker, ns_parser.n_num)
 
+        if df_tweets.empty:
+            return
+
         # Parse tweets
         dt_from = dparse.parse(df_tweets["created_at"].values[-1])
         dt_to = dparse.parse(df_tweets["created_at"].values[0])
@@ -246,17 +249,23 @@ def sentiment(other_args: List[str], s_ticker: str):
                 break
             # Update past datetime
             dt_past = dt_recent - timedelta(minutes=60)
-            if dt_past.day < dt_recent.day:
-                print(
-                    f"From {dt_past.date()} retrieving {ns_parser.n_tweets*24} tweets ({ns_parser.n_tweets} tweets/hour)"
-                )
+
             temp = load_analyze_tweets(
                 s_ticker,
                 ns_parser.n_tweets,
                 start_time=dt_past.strftime(dtformat),
                 end_time=dt_recent.strftime(dtformat),
             )
+
+            if temp.empty:
+                return
+
             df_tweets = pd.concat([df_tweets, temp])
+
+            if dt_past.day < dt_recent.day:
+                print(
+                    f"From {dt_past.date()} retrieving {ns_parser.n_tweets*24} tweets ({ns_parser.n_tweets} tweets/hour)"
+                )
 
             # Update recent datetime
             dt_recent = dt_past

--- a/gamestonk_terminal/comparison_analysis/ca_controller.py
+++ b/gamestonk_terminal/comparison_analysis/ca_controller.py
@@ -125,7 +125,7 @@ class ComparisonAnalysisController:
         print("")
 
         if self.similar:
-            print("   > po          portfolio optimization for selected tickers")
+            print(">  po          portfolio optimization for selected tickers")
             print("")
         return
 

--- a/gamestonk_terminal/comparison_analysis/finbrain_view.py
+++ b/gamestonk_terminal/comparison_analysis/finbrain_view.py
@@ -169,6 +169,7 @@ def get_sentiments(similar: List[str]) -> pd.DataFrame:
     """
 
     df_sentiment = pd.DataFrame()
+    dates_sentiment = list()
     for ticker in similar:
         result = requests.get(f"https://api.finbrain.tech/v0/sentiments/{ticker}")
         if result.status_code == 200:
@@ -177,14 +178,17 @@ def get_sentiments(similar: List[str]) -> pd.DataFrame:
                     float(val)
                     for val in list(result.json()["sentimentAnalysis"].values())
                 ]
+                dates_sentiment = list(result.json()["sentimentAnalysis"].keys())
             else:
                 print(f"Unexpected data format from FinBrain API for {ticker}")
+                similar.remove(ticker)
 
         else:
             print(f"Request error in retrieving {ticker} sentiment from FinBrain API")
+            similar.remove(ticker)
 
     if not df_sentiment.empty:
-        df_sentiment.index = list(result.json()["sentimentAnalysis"].keys())
+        df_sentiment.index = dates_sentiment
         df_sentiment.sort_index(ascending=True, inplace=True)
 
     return df_sentiment

--- a/gamestonk_terminal/discovery/disc_controller.py
+++ b/gamestonk_terminal/discovery/disc_controller.py
@@ -104,6 +104,9 @@ class DiscoveryController:
         print("   latest         latest news [Seeking Alpha]")
         print("   trending       trending news [Seeking Alpha]")
         print("   ratings        top ratings updates [MarketBeat]")
+        print(
+            "   darkpool       promising tickers based on dark pool shares regression [FINRA]"
+        )
         print("   darkshort      dark pool short position [Stockgrid.io]")
         print("   shortvol       short interest and days to cover [Stockgrid.io]")
         print("")

--- a/gamestonk_terminal/fundamental_analysis/yahoo_finance_view.py
+++ b/gamestonk_terminal/fundamental_analysis/yahoo_finance_view.py
@@ -213,9 +213,12 @@ def sustainability(other_args: List[str], ticker: str):
 
         df_sustainability = stock.sustainability
 
+        if df_sustainability is None:
+            print(f"No sustainability information in Yahoo for {ticker}", "\n")
+            return
+
         if df_sustainability.empty:
-            print(f"No sustainability information in Yahoo for {ticker}")
-            print("")
+            print(f"No sustainability information in Yahoo for {ticker}", "\n")
             return
 
         clean_df_index(df_sustainability)

--- a/gamestonk_terminal/government/quiverquant_view.py
+++ b/gamestonk_terminal/government/quiverquant_view.py
@@ -392,7 +392,6 @@ def government_trading(other_args: List[str], ticker: str, gov_type: str):
     )
 
     try:
-
         if other_args:
             if "-" not in other_args[0]:
                 other_args.insert(0, "-p")
@@ -416,6 +415,10 @@ def government_trading(other_args: List[str], ticker: str, gov_type: str):
         df_gov["TransactionDate"] = pd.to_datetime(df_gov["TransactionDate"])
 
         df_gov = df_gov[df_gov["TransactionDate"] > start_date]
+
+        if df_gov.empty:
+            print(f"No recent {gov_type} trading data found\n")
+            return
 
         df_gov["min"] = df_gov["Range"].apply(
             lambda x: x.split("-")[0].strip("$").replace(",", "").strip()

--- a/gamestonk_terminal/options/presets/template.ini
+++ b/gamestonk_terminal/options/presets/template.ini
@@ -3,6 +3,7 @@
 [FILTER]
 
 # tickers [string]: a list of space or comma separated tickers to restrict or exclude them from the query.
+# E.g. "GME" or for multiples "AMC,BB,GME".
 tickers =
 
 # exclude [true|false]: if true, then tickers are excluded. If false, the search is restricted to these tickers.
@@ -36,13 +37,13 @@ max-exp =
 min-price =
 
 # max-price [float]: maximum option premium.
-max-price =
+max-price = 0.5
 
 # calls [true|false]: select call options.
-calls =
+calls = true
 
 # puts [true|false]: select put options.
-puts =
+puts = true
 
 # stock [true|false]: select normal stocks.
 stock =

--- a/gamestonk_terminal/options/syncretism_view.py
+++ b/gamestonk_terminal/options/syncretism_view.py
@@ -162,8 +162,13 @@ PC: Price Change; PB: Price-to-book. """,
 
         if res.status_code == 200:
             df_res = pd.DataFrame(res.json())
+
+            if df_res.empty:
+                print(f"No options data found for preset: {ns_parser.preset}", "\n")
+                return
+
             df_res = df_res.rename(columns=d_cols)[list(d_cols.values())[:17]]
-            # print(df_res.to_string())
+
             print(
                 tabulate(
                     df_res,

--- a/gamestonk_terminal/papermill/README.md
+++ b/gamestonk_terminal/papermill/README.md
@@ -6,8 +6,8 @@ This menu has a different concept from remaining menus. It has 2 main goals:
 
 Command | Template | Example
 ------ | --------|----
-`dd`   | [Due Diligence Template](/notebooks/templates/due_diligence.ipynb) | todo
-`econ` | [Economy Template](/notebooks/templates/econ_data.ipynb) | todo
+`dd`   | [Due Diligence Template](/notebooks/templates/due_diligence.ipynb) | [Due Diligence Example](/notebooks/examples/GME_20210704_191432_due_diligence.html)
+`econ` | [Economy Template](/notebooks/templates/econ_data.ipynb) | [Economy Example](/notebooks/examples/econ_data_20210704_074122.html)
 
      
 ## How to run the report

--- a/gamestonk_terminal/papermill/README.md
+++ b/gamestonk_terminal/papermill/README.md
@@ -1,0 +1,30 @@
+# PAPERMILL
+
+This menu has a different concept from remaining menus. It has 2 main goals:
+ - Generate a personalised report.
+ - Allow the user to write notes on that notebook (report), as if it was his personal investment diary.
+
+Command | Template | Example
+------ | --------|----
+`dd`   | [Due Diligence Template](/notebooks/templates/due_diligence.ipynb) | todo
+`econ` | [Economy Template](/notebooks/templates/econ_data.ipynb) | todo
+
+     
+## How to run the report
+
+1. Before running the terminal, on the main directory "GamestonkTerminal" start a new notebook kernel with: `jupyter notebook`
+
+2. Now you can start the terminal with `python terminal.py`
+
+3. Select `mill` and select one of the available reports generation
+
+4. This should prompt you with a filled notebok with name: `report_name_date_time.ipynb` 
+
+5. You can now write your own personal notes on the notebook. By doing:
+   * Click on the notebook cell that you are interested in writing your notes
+   * On the toolbar click on "+" to add a new cell
+   * On the tooblar click on "Cell" -> "Cell Type" -> "Markdown"
+   * You're now ready to write your own notes
+
+6. Once you're happy with your report, you can export it by doing:
+   * On the toolbar click on "File" -> "Download as" -> Select your preferred option (e.g. HTML)

--- a/gamestonk_terminal/papermill/papermill_controller.py
+++ b/gamestonk_terminal/papermill/papermill_controller.py
@@ -64,8 +64,10 @@ class PapermillController:
 
 def print_papermill():
     """Print help"""
-
-    print("\nDiscovery Mode:")
+    print(
+        "https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/gamestonk_terminal/papermill"
+    )
+    print("\nPapermill Reports:")
     print("   help          show this papermill menu again")
     print("   q             quit this menu, and shows back to main menu")
     print("   quit          quit to abandon program")

--- a/gamestonk_terminal/residuals_analysis/ra_controller.py
+++ b/gamestonk_terminal/residuals_analysis/ra_controller.py
@@ -146,6 +146,8 @@ class ResidualsController:
                     other_args[2:], self.stock
                 )
 
+            self.print_help()
+
         except Exception as e:
             print(e)
 


### PR DESCRIPTION
This PR contains following bugixes (reported by @octoshrimpy):
- Add darkpool command in help, which was missing
- Call help after picking model on Residual Analysis
- Add another check in gov/house to see if there's no recent data
- op screener README improved + empty dataframe error message
- Fail gracefully when no fa/sust data
- Fail straight when wrong twitter API key provided
- ca/sentiment to still work if last ticker doesn't exist

It also adds a README file to papermill, since some users didn't know how to use it.