### PR TITLE
Fix dd warnings debug output

### DIFF
--- a/gamestonk_terminal/due_diligence/market_watch_view.py
+++ b/gamestonk_terminal/due_diligence/market_watch_view.py
@@ -328,16 +328,16 @@ def sean_seah_warnings(other_args: List[str], ticker: str):
             print("5x Net Income < Long-Term Debt")
             n_warnings += 1
             if ns_parser.b_debug:
-                sa_net_income = np.array2string(
-                    df_sean_seah.loc["Net Income"].values,
+                sa_5_net_income = np.array2string(
+                    5 * df_sean_seah.loc["Net Income"].values,
                     formatter={"float_kind": lambda x: int_or_round_float(x)},
                 )
-                print(f"   NET Income: {sa_net_income}")
-                sa_5_long_term_debt = np.array2string(
-                    5 * df_sean_seah.loc["Long-Term Debt"].values,
+                print(f"   5x NET Income: {sa_5_net_income}")
+                sa_long_term_debt = np.array2string(
+                    df_sean_seah.loc["Long-Term Debt"].values,
                     formatter={"float_kind": lambda x: int_or_round_float(x)},
                 )
-                print(f"   lower than 5x Long-Term Debt: {sa_5_long_term_debt}")
+                print(f"   lower than Long-Term Debt: {sa_long_term_debt}")
 
         if np.any(df_sean_seah.loc["Interest Coverage Ratio"].values < 3):
             print("Interest coverage ratio less than 3")


### PR DESCRIPTION
Due diligence `warnings --debug` output multiplies long-term debt by 5 rather than net income [as specified by Sean Seah](https://www.drwealth.com/gone-fishing-with-buffett-by-sean-seah/comment-page-1/).

The actual test used to generate warnings is correct, so this patch updates debug output to print the same computations.