### PR TITLE
This should make so that the project is considered as python only

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* linguist-vendored
+*.py linguist-vendored=false


### PR DESCRIPTION
This should avoid the project being considered as 20% HTML, without having to remove the example files. @aia 

Relied on this: https://stackoverflow.com/questions/34713765/github-changes-repository-to-wrong-language