### PR TITLE
Feature/fraud indicators

### DIFF
--- a/gamestonk_terminal/README.md
+++ b/gamestonk_terminal/README.md
@@ -182,6 +182,7 @@ Command|Description
 `balance`       |balance sheet of the company
 `cash`          |cash flow of the company
 `earnings`      |earnings dates and reported EPS
+`fraud`         |key fraud ratios
 [Financial Modeling Prep API](https://financialmodelingprep.com/) |
 `profile`       |profile of the company
 `quote`         |quote of the company

--- a/gamestonk_terminal/fundamental_analysis/README.md
+++ b/gamestonk_terminal/fundamental_analysis/README.md
@@ -151,10 +151,7 @@ Print earnings dates and reported EPS of the company. The following fields are e
 ### fraud <a name="fraud"></a>
 
 ```text
-usage: fraud [-d] [-s]
+usage: fraud
 ```
 
 The Beneish model is a statistical model that uses financial ratios calculated with accounting data of a specific company in order to check if it is likely (high probability) that the reported earnings of the company have been manipulated.[Source: Wikipedia]
-
-* d : Descriptions flag. Default False.
-* s : Subcalcalculations flag. Default False.

--- a/gamestonk_terminal/fundamental_analysis/README.md
+++ b/gamestonk_terminal/fundamental_analysis/README.md
@@ -33,6 +33,8 @@ This menu aims to extract all fundamentals of a pre-loaded company, and the usag
   * cash flow of the company
 * [earnings](#earnings)
   * earnings dates and reported EPS
+* [fraud](#fraud)
+  * key fraud ratios
 
 
 [FINANCIAL MODELING PREP menu](/gamestonk_terminal/fundamental_analysis/financial_modeling_prep/)
@@ -145,3 +147,14 @@ Print earnings dates and reported EPS of the company. The following fields are e
 
 * n : Number of latest years/quarters. Default 1.
 * q : Quarter fundamental data flag. Default False.
+
+### fraud <a name="fraud"></a>
+
+```text
+usage: fraud [-d] [-s]
+```
+
+The Beneish model is a statistical model that uses financial ratios calculated with accounting data of a specific company in order to check if it is likely (high probability) that the reported earnings of the company have been manipulated.[Source: Wikipedia]
+
+* d : Descriptions flag. Default False.
+* s : Subcalcalculations flag. Default False.

--- a/gamestonk_terminal/fundamental_analysis/av_view.py
+++ b/gamestonk_terminal/fundamental_analysis/av_view.py
@@ -518,24 +518,6 @@ def clean_fundamentals_df(df_fa: pd.DataFrame, num: int) -> pd.DataFrame:
 
     return df_fa
 
-def clean_mscore_df(df_fa: pd.DataFrame) -> List[int]:
-    """Clean fundamentals dataframe
-
-    Parameters
-    ----------
-    df_fa : pd.DataFrame
-        Fundamentals dataframe
-
-    Returns
-    ----------
-    List[int]
-        Last two years cleaned
-    """
-    # pylint: disable=no-member
-    ints = [int(x) for x in df_fa.to_list()]
-
-    return ints
-
 
 def mscore(other_args: List[str], ticker: str):
     """Mscore for given ticker
@@ -592,20 +574,20 @@ def mscore(other_args: List[str], ticker: str):
         df_bs = df_bs.set_index("fiscalDateEnding").iloc[:2]
         df_is = df_is.set_index("fiscalDateEnding").iloc[:2]
 
-        ar = clean_mscore_df(df_bs["currentNetReceivables"])
-        sales = clean_mscore_df(df_is["totalRevenue"])
-        cogs = clean_mscore_df(df_is["costofGoodsAndServicesSold"])
-        ca = clean_mscore_df(df_bs["totalCurrentAssets"])
-        ppe = clean_mscore_df(df_bs["propertyPlantEquipment"])
-        cash = clean_mscore_df(df_bs["cashAndCashEquivalentsAtCarryingValue"])
-        cash_and_sec = clean_mscore_df(df_bs["cashAndShortTermInvestments"])
+        ar = [int(x) for x in df_bs["currentNetReceivables"].to_list()]
+        sales = [int(x) for x in df_is["totalRevenue"].to_list()]
+        cogs = [int(x) for x in df_is["costofGoodsAndServicesSold"].to_list()]
+        ca = [int(x) for x in df_bs["totalCurrentAssets"].to_list()]
+        ppe = [int(x) for x in df_bs["propertyPlantEquipment"].to_list()]
+        cash = [int(x) for x in df_bs["cashAndCashEquivalentsAtCarryingValue"].to_list()]
+        cash_and_sec = [int(x) for x in df_bs["cashAndShortTermInvestments"].to_list()]
         sec = [y - x for (x, y) in zip(cash, cash_and_sec)]
-        ta = clean_mscore_df(df_bs["totalAssets"])
-        dep = clean_mscore_df(df_bs["accumulatedDepreciationAmortizationPPE"])
-        sga = clean_mscore_df(df_is["sellingGeneralAndAdministrative"])
-        td = clean_mscore_df(df_bs["totalLiabilities"])
-        icfo = clean_mscore_df(df_is["netIncomeFromContinuingOperations"])
-        cfo = clean_mscore_df(df_cf["operatingCashflow"])
+        ta = [int(x) for x in df_bs["totalAssets"].to_list()]
+        dep = [int(x) for x in df_bs["accumulatedDepreciationAmortizationPPE"].to_list()]
+        sga = [int(x) for x in df_is["sellingGeneralAndAdministrative"].to_list()]
+        td = [int(x) for x in df_bs["totalLiabilities"].to_list()]
+        icfo = [int(x) for x in df_is["netIncomeFromContinuingOperations"].to_list()]
+        cfo = [int(x) for x in df_cf["operatingCashflow"].to_list()]
         ratios = {}
         ratios["DSRI"] = {"raw": (ar[0] / sales[0]) / (ar[1] / sales[1]),
                         "description": """Days Sales in Receivables Index gauges whether receivables and revenue are out of balance, a large number is expected to be associated with a higher likelihood that revenues and earnings are overstated."""
@@ -650,7 +632,5 @@ def mscore(other_args: List[str], ticker: str):
                 print(ratios["MSCORE"]["description"])
             print("MSCORE" + ": " + str(ratios["MSCORE"]["raw"]))
 
-
-    except Exception as e:
-        print(e, "\n")
-
+    except ValueError:
+        print("The ticker does not have complete information so a mscore analysis cannot be ran.")

--- a/gamestonk_terminal/fundamental_analysis/av_view.py
+++ b/gamestonk_terminal/fundamental_analysis/av_view.py
@@ -596,8 +596,8 @@ def mscore(other_args: List[str], ticker: str):
         ratios["DSRI"] = {
             "raw": (ar[0] / sales[0]) / (ar[1] / sales[1]),
             "description": (
-                "Days Sales in Receivables Index gauges whether receivables and"
-                "revenue are out of balance, a large number is expected to be associated with a"
+                "Days Sales in Receivables Index gauges whether receivables and "
+                "revenue are out of balance, a large number is expected to be associated with a "
                 "higher likelihood that revenues and earnings are overstated."
             ),
         }
@@ -605,9 +605,9 @@ def mscore(other_args: List[str], ticker: str):
             "raw": ((sales[1] - cogs[1]) / sales[1])
             / ((sales[0] - cogs[0]) / sales[0]),
             "description": (
-                "Gross Margin Index shows if gross margins are deteriorating."
-                "Research suggests that firms with worsening gross margin are more likely to engage"
-                "in earnings management, therefore there should be a positive correlation between GMI"
+                "Gross Margin Index shows if gross margins are deteriorating. "
+                "Research suggests that firms with worsening gross margin are more likely to engage "
+                "in earnings management, therefore there should be a positive correlation between GMI "
                 "and probability of earnings management."
             ),
         }
@@ -615,47 +615,47 @@ def mscore(other_args: List[str], ticker: str):
             "raw": (1 - ((ca[0] + ppe[0] + sec[0]) / ta[0]))
             / (1 - ((ca[1] + ppe[1] + sec[1]) / ta[1])),
             "description": (
-                "Asset Quality Index measures the proportion of assets where"
-                "potential benefit is less certain. A positive relation between AQI and earnings"
+                "Asset Quality Index measures the proportion of assets where "
+                "potential benefit is less certain. A positive relation between AQI and earnings "
                 "manipulation is expected."
             ),
         }
         ratios["SGI"] = {
             "raw": sales[0] / sales[1],
             "description": (
-                "Sales Growth Index shows the amount of growth companies are having."
-                "Higher growth companies are more likely to commit fraud so there should be a"
+                "Sales Growth Index shows the amount of growth companies are having. "
+                "Higher growth companies are more likely to commit fraud so there should be a "
                 "positive relation between SGI and earnings management."
             ),
         }
         ratios["DEPI"] = {
             "raw": (dep[1] / (ppe[1] + dep[1])) / (dep[0] / (ppe[0] + dep[0])),
             "description": (
-                "Depreciation Index is the ratio for the rate of depreciation. A DEPI"
-                "greater than 1 shows that the depreciation rate has slowed and is positively"
+                "Depreciation Index is the ratio for the rate of depreciation. A DEPI "
+                "greater than 1 shows that the depreciation rate has slowed and is positively "
                 "correlated with earnings management."
             ),
         }
         ratios["SGAI"] = {
             "raw": (sga[0] / sales[0]) / (sga[1] / sales[1]),
             "description": (
-                "Sales General and Administrative Expenses Index measures the change"
-                "in SG&A over sales. There should be a positive relationship between SGAI and"
+                "Sales General and Administrative Expenses Index measures the change "
+                "in SG&A over sales. There should be a positive relationship between SGAI and "
                 "earnings management."
             ),
         }
         ratios["LVGI"] = {
             "raw": (td[0] / ta[0]) / (td[1] / ta[1]),
             "description": (
-                "Leverage Index represents change in leverage. A LVGI greater than"
+                "Leverage Index represents change in leverage. A LVGI greater than "
                 "one indicates a lowe change of fraud."
             ),
         }
         ratios["TATA"] = {
             "raw": (icfo[0] - cfo[0]) / ta[0],
             "description": (
-                "Total Accruals to Total Assets is a proxy for the extent that cash"
-                "underlies earnigns. A higher number is associated with a higher likelihood of"
+                "Total Accruals to Total Assets is a proxy for the extent that cash "
+                "underlies earnigns. A higher number is associated with a higher likelihood of "
                 "earnings manipulation."
             ),
         }
@@ -671,10 +671,10 @@ def mscore(other_args: List[str], ticker: str):
                 - (0.327 * ratios["LVGI"]["raw"])
             ),
             "description": (
-                "The Beneish model uses financial ratios to check if it is likely"
-                "that earnings are manipulated. A score of -5 to -2.22 indicated a low chance of"
-                "fraud, a score of -2.22 to -1.78 indicates a moderate change of fraud, and a score"
-                "above -1.78 indicated a high chance of fraud."
+                "The Beneish model uses financial ratios to check if it is likely "
+                "that earnings are manipulated. A score of -5 to -2.22 indicated a low chance of "
+                "fraud, a score of -2.22 to -1.78 indicates a moderate change of fraud, and a "
+                "score above -1.78 indicated a high chance of fraud."
             ),
         }
 

--- a/gamestonk_terminal/fundamental_analysis/fa_controller.py
+++ b/gamestonk_terminal/fundamental_analysis/fa_controller.py
@@ -35,6 +35,7 @@ class FundamentalAnalysisController:
         "quit",
         "score",
         "screener",
+        "fraud",
         "income",
         "balance",
         "cash",
@@ -114,6 +115,7 @@ class FundamentalAnalysisController:
         print("   balance       balance sheet of the company")
         print("   cash          cash flow of the company")
         print("   earnings      earnings dates and reported EPS")
+        print("   fraud         key fraud ratios")
         print("")
         print("Other Sources:")
         print(">  fmp           Financial Modeling Prep MENU")
@@ -221,6 +223,10 @@ class FundamentalAnalysisController:
     def call_earnings(self, other_args: List[str]):
         """Process earnings command"""
         av_view.earnings(other_args, self.ticker)
+
+    def call_fraud(self, other_args: List[str]):
+        """Process fraud command"""
+        av_view.mscore(other_args, self.ticker)
 
     def call_fmp(self, _):
         """Process fmp command"""

--- a/gamestonk_terminal/main_helper.py
+++ b/gamestonk_terminal/main_helper.py
@@ -656,7 +656,6 @@ def check_api_keys():
         df = TimeSeries(
             key=cfg.API_KEY_ALPHAVANTAGE, output_format="pandas"
         ).get_intraday(symbol="AAPL")
-        print(type(df[0]))
         if df[0].empty:
             key_dict["ALPHA_VANTAGE"] = "defined, test failed"
         else:

--- a/gamestonk_terminal/main_helper.py
+++ b/gamestonk_terminal/main_helper.py
@@ -654,9 +654,10 @@ def check_api_keys():
         key_dict["ALPHA_VANTAGE"] = "Not defined"
     else:
         df = TimeSeries(
-            key=cfg.API_KEY.ALPHAVANTAGE, output_format="pandas"
+            key=cfg.API_KEY_ALPHAVANTAGE, output_format="pandas"
         ).get_intraday(symbol="AAPL")
-        if df.empty:
+        print(type(df[0]))
+        if df[0].empty:
             key_dict["ALPHA_VANTAGE"] = "defined, test failed"
         else:
             key_dict["ALPHA_VANTAGE"] = "defined, test passed"


### PR DESCRIPTION
I am adding a fraud score based using Beneish's mscore. Since this is based on fundamental analysis I have put it under the fa section, and I have put it under the Alpha Vantage section since it utilizes that API. Users can use the -s flag to get a breakdown on the different components of the mscore. Additionally, users can use the -d flag to get details on what the value of the mscore means. Using -s and -d together results in a detailed explanation of the mscore and all components.