### PR TITLE
Specify the path to .env file for using dotenv

### DIFF
--- a/gamestonk_terminal/config_terminal.py
+++ b/gamestonk_terminal/config_terminal.py
@@ -1,7 +1,9 @@
 import os
 from dotenv import load_dotenv
 
-load_dotenv()
+env_files = [f for f in os.listdir() if f.endswith(".env")]
+if env_files:
+    load_dotenv(env_files[0])
 
 # By default the jupyter notebook will be run on port 8888
 PAPERMILL_NOTEBOOK_REPORT_PORT = "8888"


### PR DESCRIPTION
I was having the issue that `load_dotenv()` wasn't reading the only .env file in the current directory.  

I just made a quick fix that points to the .env file if it is present