### PR TITLE
Change `events` sorting and make `ratings` legacy

### DIFF
--- a/gamestonk_terminal/README.md
+++ b/gamestonk_terminal/README.md
@@ -103,7 +103,6 @@ Command|Description|Source
 `spectrum`      |spectrum of sectors, industry, country |[Finviz](https://finviz.com)
 `latest`        |latest news |[Seeking Alpha](https://seekingalpha.com/)
 `trending`      |trending news |[Seeking Alpha](https://seekingalpha.com/)
-`ratings`       |top ratings updates |[MarketBeat](https://marketbeat.com)
 `darkpool`      |dark pool tickers with growing activity |[FINRA](https://www.finra.org)
 `darkshort`     |dark pool short position|[Stockgrid](https://stockgrid.io)
 `shortvol`      |short interest and days to cover |[Stockgrid](https://stockgrid.io)

--- a/gamestonk_terminal/discovery/README.md
+++ b/gamestonk_terminal/discovery/README.md
@@ -38,8 +38,6 @@ This menu aims to discover new stocks, and the usage of the following commands a
   * latest news [Seeking Alpha]
 * [trending](#trending)
   * trending news [Seeking Alpha]
-* [ratings](#ratings)
-  * top ratings updates [MarketBeat]
 * [darkpool](#darkpool)
   * dark pool tickers with growing activity [FINRA]
 * [darkshort](#darkshort)
@@ -276,19 +274,6 @@ Trending news articles. [Source: Seeking Alpha]
 * -n : Number of articles being printed. Default 10.
 
 <img width="1213" alt="trending" src="https://user-images.githubusercontent.com/25267873/115089640-96988780-9f0a-11eb-9ca7-70a245fa3960.png">
-
-
-## ratings <a name="ratings"></a>
-
-```
-usage: ratings [-t N_THRESHOLD]
-```
-
-Top ratings updates. [Source: MarketBeat]
-
-* -t : Minimum threshold in percentage change between current and target price to show ratings. Default: 100.
-
-<img width="963" alt="ratings" src="https://user-images.githubusercontent.com/25267873/115095983-4544c400-9f1b-11eb-8869-8ec8a0f8eae0.png">
 
 
 ## darkpool <a name="darkpool"></a>

--- a/gamestonk_terminal/discovery/disc_controller.py
+++ b/gamestonk_terminal/discovery/disc_controller.py
@@ -20,7 +20,6 @@ from gamestonk_terminal.discovery import (
     spachero_view,
     unusual_whales_view,
     yahoo_finance_view,
-    marketbeat_view,
     finra_ats_view,
     finnhub_view,
     stockgrid_view,
@@ -54,7 +53,6 @@ class DiscoveryController:
         "valuation",
         "performance",
         "spectrum",
-        "ratings",
         "latest",
         "trending",
         "darkpool",
@@ -109,7 +107,6 @@ class DiscoveryController:
         print("   spectrum       spectrum of sectors, industry, country [Finviz]")
         print("   latest         latest news [Seeking Alpha]")
         print("   trending       trending news [Seeking Alpha]")
-        print("   ratings        top ratings updates [MarketBeat]")
         print(
             "   darkpool       promising tickers based on dark pool shares regression [FINRA]"
         )
@@ -247,10 +244,6 @@ class DiscoveryController:
     def call_trending(self, other_args: List[str]):
         """Process trending command"""
         seeking_alpha_view.trending_news_view(other_args)
-
-    def call_ratings(self, other_args: List[str]):
-        """Process ratings command"""
-        marketbeat_view.ratings_view(other_args)
 
     def call_darkpool(self, other_args: List[str]):
         """Process darkpool command"""

--- a/gamestonk_terminal/economy/finnhub_view.py
+++ b/gamestonk_terminal/economy/finnhub_view.py
@@ -90,10 +90,10 @@ def economy_calendar_events(other_args: List[str]):
 
         df_econ_calendar = df_events[
             df_events["country"] == ns_parser.country
-        ].sort_values("time", ascending=False)
+        ].sort_values("time", ascending=True)
 
         if df_econ_calendar.empty:
-            print("No latet economy calendar events found in the specified country\n")
+            print("No latest economy calendar events found in the specified country\n")
             return
 
         if ns_parser.impact != "all":


### PR DESCRIPTION
Title.

- Changed events sorting so it displays closest events first
- Deleted disc->ratings from options.  Marketbeat code still there.