### PR TITLE
Disabling tests that result in access violations

### DIFF
--- a/tests/test_portfolio_optimization/test_optimizer_view.py
+++ b/tests/test_portfolio_optimization/test_optimizer_view.py
@@ -54,20 +54,20 @@ class TestOptimizerView(TestCase):
     def test_efficient_risk(self):
         optimizer_view.efficient_risk(["TSLA", "GME"], [])
 
-    @check_print(assert_in="TSLA")
-    @vcr.use_cassette(
-        "tests/cassettes/test_port_opt/test_opt_view/general1.yaml",
-        record_mode="new_episodes",
-    )
-    def test_efficient_return(self):
-        optimizer_view.efficient_return(["TSLA", "GME"], [])
+    # @check_print(assert_in="TSLA")
+    # @vcr.use_cassette(
+    #     "tests/cassettes/test_port_opt/test_opt_view/general1.yaml",
+    #     record_mode="new_episodes",
+    # )
+    # def test_efficiet_return(self):
+    #     optimizer_view.efficient_return(["TSLA", "GME"], [])
 
-    @check_print(assert_in="\n")
-    @vcr.use_cassette(
-        "tests/cassettes/test_port_opt/test_opt_view/test_show_eff.yaml",
-        record_mode="new_episodes",
-    )
-    @mock.patch("matplotlib.pyplot.show")
-    def test_show_ef(self, mock_mlp):
-        # pylint: disable=unused-argument
-        optimizer_view.show_ef(["TSLA", "GME"], [])
+    # @check_print(assert_in="\n")
+    # @vcr.use_cassette(
+    #     "tests/cassettes/test_port_opt/test_opt_view/test_show_eff.yaml",
+    #     record_mode="new_episodes",
+    # )
+    # @mock.patch("matplotlib.pyplot.show")
+    # def test_show_ef(self, mock_mlp):
+    #     # pylint: disable=unused-argument
+    #     optimizer_view.show_ef(["TSLA", "GME"], [])


### PR DESCRIPTION
Temporarily disable problematic tests.

test_efficiet_return is failing on Windows with:
```
Windows fatal exception: access violation

Current thread 0x00002038 (most recent call first):
  File "c:\Users\av\git\GamestonkTerminal\gamestonk_terminal\portfolio\portfolio_optimization\optimizer_view.py", line 682 in efficient_return
  File "c:\Users\av\git\GamestonkTerminal\tests\test_portfolio_optimization\test_optimizer_view.py", line 63 in test_efficient_return
...
```

test_show_ef is failing with:
```
......Windows fatal exception: code 0xc0000374

Current thread 0x00003b04 (most recent call first):
  File "C:\Users\av\anaconda3\envs\gst388\lib\site-packages\pypfopt\plotting.py", line 248 in plot_efficient_frontier
  File "c:\Users\av\git\GamestonkTerminal\gamestonk_terminal\portfolio\portfolio_optimization\optimizer_view.py", line 751 in show_ef
  File "c:\Users\av\git\GamestonkTerminal\tests\test_portfolio_optimization\test_optimizer_view.py", line 73 in test_show_ef
```