### PR TITLE
Add docker documentation

### DIFF
--- a/DOCKER_ADVANCED.md
+++ b/DOCKER_ADVANCED.md
@@ -40,6 +40,8 @@ For help setting up the X-Server, I will go through this now:
 
 0. Install X Quartz from  https://www.xquartz.org/
 1. With X Quartz open: go to Preferences -> Security and make sure both options are enabled.
+![Screen Shot 2021-09-08 at 12 21 48 PM](https://user-images.githubusercontent.com/18151143/132548605-235d774b-9aa6-4a45-afcf-58fb775d376a.png)
+
 
 ### Adding the display for Docker
 

--- a/DOCKER_ADVANCED.md
+++ b/DOCKER_ADVANCED.md
@@ -1,0 +1,56 @@
+# Docker Advanced Settings
+
+## Environment Variables
+
+In order to pass your API keys to the docker container, they must first be set in a local file.  In the main repository, there is a file with predefined keys and terminal settings [setenv](gamestonk_terminal/docker/setenv).  This can be downloaded or created on your own
+
+The file should contain something such as:
+```
+GT_API_KEY_FINANCIALMODELINGPREP="YOUR_KEY"
+GT_API_REDDIT_CLIENT_ID="YOUR_KEY"
+GT_API_REDDIT_CLIENT_SECRET="YOUR_KEY"
+GT_API_REDDIT_USERNAME="YOUR_KEY"
+GT_API_REDDIT_USER_AGENT=Python
+GT_API_REDDIT_PASSWORD="YOUR_KEY"
+GT_API_TWITTER_KEY="YOUR_KEY"
+GT_API_TWITTER_SECRET_KEY="YOUR_KEY"
+GT_FRED_API_KEY="YOUR_KEY"
+
+HDF5_DISABLE_VERSION_CHECK=2
+
+GTFF_ENABLE_PREDICT=True
+GTFF_ENABLE_THOUGHTS_DAY=False
+GTFF_USE_PROMPT_TOOLKIT=True
+GTFF_USE_ION=True
+```
+
+In order to run the docker container with the environment variables, make sure to edit with whatever keys you have and then run the container (`path/to/file`) should be replaced with wherever this file was created).  If you have downloaded the entire repository and your current directory is `GamestonkTerminal`, then the path would be `docker/setenv`
+
+```
+docker run -it --rm --env-file=path/to/file ghcr.io/gamestonkterminal/gst-poetry:latest
+```
+
+## X-Server
+
+In order to display plots in the docker container, we need to configure our XServer.  Users familiar with Docker can just set the DISPLAY variable in their file described above.
+
+For help setting up the X-Server, I will go through this now:
+
+### Setting up X Quartz/X11
+
+0. Install X Quartz from  https://www.xquartz.org/
+1. With X Quartz open: go to Preferences -> Security and make sure both options are enabled.
+
+### Adding the display for Docker
+
+From the command prompt or terminal, run the following to add your local configuration to the list of allowed access control:
+```bash
+IP=$(ifconfig en1 | grep inet | awk '$1=="inet" {print $2}')
+xhost + $IP
+```
+
+Now we can run the docker container, adding the display to the environment:
+```bach
+docker run -it --rm --env-file=path/to/file -e DISPLAY=$IP:0 ghcr.io/gamestonkterminal/gst-poetry:latest
+```
+This container will be able to display all the same plots as the terminal interface.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Open the docker desktop app in this case.
 docker pull ghcr.io/gamestonkterminal/gst-poetry:latest
 ```
 
-Upon running this the first time, you should see the various layers downloading (note the random series of letters numbers will vary).
+Upon running this the first time, you should see the various layers downloading (note the random series of letters numbers will vary).  The first time this is run, it will take a few minutes.  Subsequent updates will be much faster, as the changes will be in the MB instead of GB.
 ![Screen Shot 2021-09-08 at 10 41 08 AM](https://user-images.githubusercontent.com/18151143/132531075-7d7f7e71-4fcb-435c-9bb3-466d7077eba4.png)
 
 Once the download is complete, confirm that the image has been created by doing `docker images`.  You should see something similar to
@@ -122,7 +122,7 @@ This will open up the terminal in your command prompt or terminal.  Note that th
 
 To read more on adding the environment keys and how to configure your X-server to show plots, hop over to the [Advanced Docker Setup](/DOCKER_ADVANCED.md).
 
-### Install
+### Local Install - Anaconda and Python
 
 If you'd like to see a video recording of the installation process, @JohnnyDankseed has made one available [here](https://www.youtube.com/watch?v=-DJJ-cfquDA).
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,41 @@ As a modern Python-based environment, GamestonkTerminal opens access to numerous
 
 ## Getting Started
 
+### Docker Installation - *new and improved*
+
+0. First step is to make sure docker desktop is installed.  Install likes can be found [here](#https://www.docker.com/products/docker-desktop).  To confirm that your docker desktop is downloaded and running, open a command prompt or terminal and enter
+`docker info`.  If you get the following you are not running the docker desktop:
+```bash
+Server:
+ERROR: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+Open the docker desktop app in this case.
+
+1. Download the latest docker image.
+
+```bash
+docker pull ghcr.io/gamestonkterminal/gst-poetry:latest
+```
+
+Upon running this the first time, you should see the various layers downloading (note the random series of letters numbers will vary).
+![Screen Shot 2021-09-08 at 10 41 08 AM](https://user-images.githubusercontent.com/18151143/132531075-7d7f7e71-4fcb-435c-9bb3-466d7077eba4.png)
+
+Once the download is complete, confirm that the image has been created by doing `docker images`.  You should see something similar to
+```bash
+REPOSITORY                             TAG       IMAGE ID       CREATED        SIZE
+ghcr.io/gamestonkterminal/gst-poetry   latest    e2bbeebcc73c   42 hours ago   2.02GB
+```
+
+2. Run a container
+
+You are now ready to run the terminal.  
+
+```docker run -it --rm ghcr.io/gamestonkterminal/gst-poetry:latest```
+
+This will open up the terminal in your command prompt or terminal.  Note that this has provided now environment file, so you will not be able to view plots or use keys at this stage.
+
+To read more on adding the environment keys and how to configure your X-server to show plots, hop over to the [Advanced Docker Guide?].
+
 ### Install
 
 If you'd like to see a video recording of the installation process, @JohnnyDankseed has made one available [here](https://www.youtube.com/watch?v=-DJJ-cfquDA).
@@ -183,24 +218,6 @@ ENABLE_PREDICT = os.getenv("GTFF_ENABLE_PREDICT") or True
 ```
 poetry install -E prediction
 ```
-
-*If you would like to set up a docker image:*
-
-* Build the docker:
-
-```
-docker-compose -f docker/docker-compose.yaml build gst-python
-docker-compose -f docker/docker-compose.yaml build gst-poetry-deps
-docker-compose -f docker/docker-compose.yaml build gst-poetry
-```
-
-* Run it:
-
-```
-docker run -it --env-file=docker/setenv --rm gst/gst-poetry:1.1.0
-```
-
-Note: Remember to customize your docker/setenv.
 
 ### Update Terminal
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
     <li>
       <a href="#getting-started">Getting Started</a>
       <ul>
+        <li><a href="#dock-install">Docker Install</a></li>
         <li><a href="#install">Install</a></li>
         <li><a href="#advanced-user-install---machine-learning">Advanced User Install - Machine Learning</a></li>
         <li><a href="#update-terminal">Update Terminal</a></li>
@@ -88,7 +89,7 @@ As a modern Python-based environment, GamestonkTerminal opens access to numerous
 
 ### Docker Installation - *new and improved*
 
-0. First step is to make sure docker desktop is installed.  Install likes can be found [here](#https://www.docker.com/products/docker-desktop).  To confirm that your docker desktop is downloaded and running, open a command prompt or terminal and enter
+0. First step is to make sure docker desktop is installed.  Install links can be found [here](https://www.docker.com/products/docker-desktop).  To confirm that your docker desktop is downloaded and running, open a command prompt or terminal and enter
 `docker info`.  If you get the following you are not running the docker desktop:
 ```bash
 Server:
@@ -113,13 +114,13 @@ ghcr.io/gamestonkterminal/gst-poetry   latest    e2bbeebcc73c   42 hours ago   2
 
 2. Run a container
 
-You are now ready to run the terminal.  
+You are now ready to run the terminal.
 
 ```docker run -it --rm ghcr.io/gamestonkterminal/gst-poetry:latest```
 
 This will open up the terminal in your command prompt or terminal.  Note that this has provided now environment file, so you will not be able to view plots or use keys at this stage.
 
-To read more on adding the environment keys and how to configure your X-server to show plots, hop over to the [Advanced Docker Guide?].
+To read more on adding the environment keys and how to configure your X-server to show plots, hop over to the [Advanced Docker Setup](/DOCKER_ADVANCED.md).
 
 ### Install
 


### PR DESCRIPTION
This PR adds the documentation for pulling the latest tag from the ghcr.io and running.

The DOCKER_ADVANCED goes into the env_files and the X Server.  My description of setting up the x server may be kind of confusing, but I could not get it to work with a single DISPLAY env variable, so feel free to PR on this with alternative approaches.