### PR TITLE
Allow for shorthand menu input

### DIFF
--- a/gamestonk_terminal/forex/forex_controller.py
+++ b/gamestonk_terminal/forex/forex_controller.py
@@ -9,7 +9,8 @@ from gamestonk_terminal import config_terminal as cfg
 from gamestonk_terminal import feature_flags as gtff
 from gamestonk_terminal.forex import fx_view
 from gamestonk_terminal.forex.behavioural_analysis import ba_controller
-from gamestonk_terminal.forex.exploratory_data_analysis import eda_controller
+
+# from gamestonk_terminal.forex.exploratory_data_analysis import eda_controller
 from gamestonk_terminal.helper_funcs import get_flair
 from gamestonk_terminal.menu import session
 
@@ -50,7 +51,7 @@ class ForexController:
     ]
 
     CHOICES_MENUS = [
-        "eda",
+        # "eda",
         "ba",
     ]
 
@@ -100,9 +101,9 @@ class ForexController:
                 "   reddit        search reddit for posts about the loaded instrument"
             )
             print("")
-            print(
-                ">  eda         exploratory data analysis,	 e.g.: decompose, cusum, residuals analysis"
-            )
+            # print(
+            #    ">  eda         exploratory data analysis,	 e.g.: decompose, cusum, residuals analysis"
+            # )
             print(
                 ">  ba          behavioural analysis,    	 from: reddit, stocktwits, twitter, google"
             )
@@ -208,16 +209,16 @@ class ForexController:
 
     # TODO: Add news and reddit commands back
 
-    def call_eda(self, _):
-        try:
-            df = fx_view.get_candles_dataframe(account, self.instrument, None)
-            df = df.rename(columns={"Close": "Adj Close"})
-            instrument = self.instrument
-            s_start = pd.to_datetime(df.index.values[0])
-            s_interval = "1440min"
-            eda_controller.menu(df, instrument, s_start, s_interval)
-        except AttributeError:
-            print("No data found, do you have your oanda API keys set?")
+    # def call_eda(self, _):
+    #    try:
+    #        df = fx_view.get_candles_dataframe(account, self.instrument, None)
+    #        df = df.rename(columns={"Close": "Adj Close"})
+    #        instrument = self.instrument
+    #        s_start = pd.to_datetime(df.index.values[0])
+    #        s_interval = "1440min"
+    #        eda_controller.menu(df, instrument, s_start, s_interval)
+    #    except AttributeError:
+    #        print("No data found, do you have your oanda API keys set?")
 
     def call_ba(self, _):
         instrument = fx_view.format_instrument(self.instrument, " ")

--- a/terminal.py
+++ b/terminal.py
@@ -164,9 +164,7 @@ What do you want to do?
 
     def call_s(self, _):
         """Process stocks command"""
-        from gamestonk_terminal.stocks import stocks_controller
-
-        return stocks_controller.menu()
+        return self.call_stocks(_)
 
     def call_crypto(self, _):
         """Process crypto command"""
@@ -176,9 +174,7 @@ What do you want to do?
 
     def call_c(self, _):
         """Process crypto command"""
-        from gamestonk_terminal.cryptocurrency import crypto_controller
-
-        return crypto_controller.menu()
+        return self.call_crypto(_)
 
     def call_economy(self, _):
         """Process economy command"""
@@ -188,9 +184,7 @@ What do you want to do?
 
     def call_e(self, _):
         """Process economy command"""
-        from gamestonk_terminal.economy import economy_controller
-
-        return economy_controller.menu()
+        return self.call_economy(_)
 
     def call_options(self, _):
         """Process options command"""
@@ -200,9 +194,7 @@ What do you want to do?
 
     def call_o(self, _):
         """Process options command"""
-        from gamestonk_terminal.options import options_controller
-
-        return options_controller.menu()
+        return self.call_options(_)
 
     def call_etf(self, _):
         """Process etf command"""
@@ -218,9 +210,7 @@ What do you want to do?
 
     def call_f(self, _):
         """Process forex command"""
-        from gamestonk_terminal.forex import forex_controller
-
-        return forex_controller.menu()
+        return self.call_forex(_)
 
     def call_resources(self, _):
         """Process resources command"""
@@ -230,9 +220,7 @@ What do you want to do?
 
     def call_r(self, _):
         """Process resources command"""
-        from gamestonk_terminal.resources import resources_controller
-
-        return resources_controller.menu()
+        return self.call_resources(_)
 
     def call_portfolio(self, _):
         """Process portfolio command"""
@@ -242,9 +230,7 @@ What do you want to do?
 
     def call_p(self, _):
         """Process portfolio command"""
-        from gamestonk_terminal.portfolio import portfolio_controller
-
-        return portfolio_controller.menu()
+        return self.call_portfolio(_)
 
 
 def terminal():

--- a/terminal.py
+++ b/terminal.py
@@ -42,6 +42,7 @@ class TerminalController:
         "keys",
     ]
 
+    CHOICES_SHORTHAND_MENUS = ["s", "e", "c", "p", "f", "o", "r"]
     CHOICES_MENUS = [
         "stocks",
         "economy",
@@ -55,6 +56,7 @@ class TerminalController:
 
     CHOICES += CHOICES_COMMANDS
     CHOICES += CHOICES_MENUS
+    CHOICES += CHOICES_SHORTHAND_MENUS
 
     def __init__(self):
         """Constructor"""
@@ -160,7 +162,19 @@ What do you want to do?
 
         return stocks_controller.menu()
 
+    def call_s(self, _):
+        """Process stocks command"""
+        from gamestonk_terminal.stocks import stocks_controller
+
+        return stocks_controller.menu()
+
     def call_crypto(self, _):
+        """Process crypto command"""
+        from gamestonk_terminal.cryptocurrency import crypto_controller
+
+        return crypto_controller.menu()
+
+    def call_c(self, _):
         """Process crypto command"""
         from gamestonk_terminal.cryptocurrency import crypto_controller
 
@@ -172,7 +186,19 @@ What do you want to do?
 
         return economy_controller.menu()
 
+    def call_e(self, _):
+        """Process economy command"""
+        from gamestonk_terminal.economy import economy_controller
+
+        return economy_controller.menu()
+
     def call_options(self, _):
+        """Process options command"""
+        from gamestonk_terminal.options import options_controller
+
+        return options_controller.menu()
+
+    def call_o(self, _):
         """Process options command"""
         from gamestonk_terminal.options import options_controller
 
@@ -190,13 +216,31 @@ What do you want to do?
 
         return forex_controller.menu()
 
+    def call_f(self, _):
+        """Process forex command"""
+        from gamestonk_terminal.forex import forex_controller
+
+        return forex_controller.menu()
+
     def call_resources(self, _):
         """Process resources command"""
         from gamestonk_terminal.resources import resources_controller
 
         return resources_controller.menu()
 
+    def call_r(self, _):
+        """Process resources command"""
+        from gamestonk_terminal.resources import resources_controller
+
+        return resources_controller.menu()
+
     def call_portfolio(self, _):
+        """Process portfolio command"""
+        from gamestonk_terminal.portfolio import portfolio_controller
+
+        return portfolio_controller.menu()
+
+    def call_p(self, _):
         """Process portfolio command"""
         from gamestonk_terminal.portfolio import portfolio_controller
 


### PR DESCRIPTION
This addresses #746 and allows for (example) s to be input instead of stocks.

Also commented out forex eda stuff so that the menu doesn't crash. Added TODO of incorporating common qa menu.

#750 was not on main branch so I am doing this instead.