### PR TITLE
Added autoinstallation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ jupyterlab/*/.ipynb_checkpoints
 jupyterlab/*/*.tsbuildinfo
 jupyterlab/*/ui-tests/test-results/
 jupyterlab/*/ui-tests/tests/*.ts-snapshots/
+
+#Data files
+data.txt


### PR DESCRIPTION
To expand our userbase I think it is important to make the startup process as easy as possible. I understand we have a docker image, but I am thinking about something much simpler than that for everyone who doesn't even know what Python or docker are and just want to do finance. This installation automatically created a virtual environment and installs all the dependencies. However, I cannot get it to open the same script inside a virtual environment once it has been clicked. @aia I was told you might be able to help me with this (see lines 394-397 of terminal.py). 