### PR TITLE
Fix options scr bug

### DIFF
--- a/gamestonk_terminal/options/syncretism_model.py
+++ b/gamestonk_terminal/options/syncretism_model.py
@@ -272,8 +272,7 @@ def check_presets(preset_dict: dict) -> str:
         elif key == "tickers":
             for ticker in value.split(","):
                 try:
-                    eval(ticker)
-                    if yf.Ticker(ticker).info["regularMarketPrice"] is None:
+                    if yf.Ticker(eval(ticker)).info["regularMarketPrice"] is None:
                         error += f"{key} : {ticker} not found on yfinance"
 
                 except NameError:


### PR DESCRIPTION
There was a bug in options screener when a ticker was provided.

The issue was in how I tested in the ticker was okay.  When reading in key, value fro the config parser, the value was actually `'"AMC"'` not just `"AMC"`, so I passed eval(Ticker) into the finance to check its valid.