### PR TITLE
Add load to dd and add empty returns to arktrades

### DIFF
--- a/gamestonk_terminal/stocks/due_diligence/ark_model.py
+++ b/gamestonk_terminal/stocks/due_diligence/ark_model.py
@@ -23,11 +23,25 @@ def get_ark_trades_by_ticker(ticker: str) -> pd.DataFrame:
     """
     url = f"https://cathiesark.com/ark-combined-holdings-of-{ticker}"
     r = requests.get(url, headers={"User-Agent": get_user_agent()})
+    # Error in request
+    if r.status_code != 200:
+        return pd.DataFrame()
+
     parsed_script = BeautifulSoup(r.text, "lxml").find(
         "script", {"id": "__NEXT_DATA__"}
     )
     parsed_json = json.loads(parsed_script.string)
+    # Return empty dataframe if there is no "trades" data
+
+    if "trades" not in parsed_json["props"]["pageProps"]:
+        return pd.DataFrame()
+
     df_orders = pd.json_normalize(parsed_json["props"]["pageProps"]["trades"])
+
+    # If trades found in dictionary, but the output is empty
+    if df_orders.empty:
+        return pd.DataFrame()
+
     df_orders = df_orders.drop(columns=["hidden", "everything.profile.customThumbnail"])
     df_orders["date"] = df_orders["date"].apply(lambda x: x.strip("Z"))
     return df_orders

--- a/gamestonk_terminal/stocks/due_diligence/ark_view.py
+++ b/gamestonk_terminal/stocks/due_diligence/ark_view.py
@@ -21,6 +21,11 @@ def display_ark_trades(ticker: str, num: int = 20, export: str = ""):
         Format to export data
     """
     ark_holdings = ark_model.get_ark_trades_by_ticker(ticker)
+
+    if ark_holdings.empty:
+        print("Issue getting data from cathiesark.com.  Likely no trades found.\n")
+        return
+
     # Since this is for a given ticker, no need to show it
     ark_holdings = ark_holdings.drop(columns=["ticker"])
 

--- a/gamestonk_terminal/stocks/due_diligence/dd_controller.py
+++ b/gamestonk_terminal/stocks/due_diligence/dd_controller.py
@@ -24,19 +24,14 @@ from gamestonk_terminal.helper_funcs import (
     EXPORT_ONLY_RAW_DATA_ALLOWED,
 )
 from gamestonk_terminal.menu import session
+from gamestonk_terminal.stocks.stocks_helper import load
 
 
 class DueDiligenceController:
     """Due Diligence Controller"""
 
     # Command choices
-    CHOICES = [
-        "?",
-        "cls",
-        "help",
-        "q",
-        "quit",
-    ]
+    CHOICES = ["?", "cls", "help", "q", "quit", "load"]
 
     CHOICES_COMMANDS = [
         "sec",
@@ -92,6 +87,7 @@ Due Diligence:
     ?/help        show this menu again
     q             quit this menu, and shows back to main menu
     quit          quit to abandon program
+    load          load new ticker
 
 {stock_text}
 
@@ -158,6 +154,12 @@ cathiesark.com
     def call_quit(self, _):
         """Process Quit command - quit the program"""
         return True
+
+    def call_load(self, other_args: List[str]):
+        """Process load command"""
+        self.ticker, self.start, self.interval, self.stock = load(
+            other_args, self.ticker, self.start, "1440min", self.stock
+        )
 
     def call_analyst(self, other_args: List[str]):
         """Process analyst command"""


### PR DESCRIPTION
Asked for on discord.  Added `load` to dd (still requiring a ticker to enter menu).

Also added some empty returns to my command from yesterday.

@DidierRLopes We need to add some kind of printing/exceptions to _models as this function has a few things that could go wrong, but since I can't print in _model I just print out a generic "Something went wrong" which helps nobody.