### PR TITLE
Fixes 2 minor issues

### DIFF
--- a/gamestonk_terminal/stocks/due_diligence/finviz_view.py
+++ b/gamestonk_terminal/stocks/due_diligence/finviz_view.py
@@ -55,7 +55,7 @@ def news(ticker: str, num: int):
     print("")
 
 
-def analyst(ticker: str, export: str):
+def analyst(ticker: str, export: str = ""):
     """Display analyst ratings. [Source: Finviz]
 
     Parameters

--- a/terminal.py
+++ b/terminal.py
@@ -278,7 +278,7 @@ def terminal(menu_prior_to_reset=""):
         else:
             print("\nInvalid DEFAULT_CONTEXT config selected!", "\n")
 
-    if process_input != MENU_QUIT:
+    if process_input not in (MENU_QUIT, MENU_RESET):
         t_controller.print_help()
 
         while True:


### PR DESCRIPTION
@colin99d your quit issue "kind of" gets fixed. I say "kind of" because now you can quit the terminal after multiple resets, BUT you'll receive multiple goodbye messages (one per reset to be more precise).

This is because of line 268 of terminal.py where we call that command after resetting the terminal, which in turn will call that command again, every time we `reset`. This creates a `stack` of returns from that reset function, one per reset. 

I spent a couple of minutes trying a workaround and couldn't find anything. I've had a similar issue in the past but don't remember how I solved it. @aia do you know how to solve this problem?
