### PR TITLE
Fix ftd encoding bug

### DIFF
--- a/gamestonk_terminal/stocks/dark_pool_shorts/sec_model.py
+++ b/gamestonk_terminal/stocks/dark_pool_shorts/sec_model.py
@@ -54,6 +54,7 @@ def get_fails_to_deliver(
                 skipfooter=2,
                 usecols=[0, 2, 3, 5],
                 dtype={"QUANTITY (FAILS)": "int"},
+                encoding="iso8859",
             )
             tmp_ftds = all_ftds[all_ftds["SYMBOL"] == ticker]
             del tmp_ftds["PRICE"]
@@ -108,6 +109,7 @@ def get_fails_to_deliver(
                 skipfooter=2,
                 usecols=[0, 2, 3, 5],
                 dtype={"QUANTITY (FAILS)": "int"},
+                encoding="iso8859",
             )
             tmp_ftds = all_ftds[all_ftds["SYMBOL"] == ticker]
             del tmp_ftds["PRICE"]


### PR DESCRIPTION
Bug in ftd,  For whatever reason the most recent ftd wasn't working with the default encoding.  Changed it to iso8859 and it works fine