### PR TITLE
Added Market Cap categorisation for the fds function

### DIFF
--- a/gamestonk_terminal/stocks/discovery/disc_controller.py
+++ b/gamestonk_terminal/stocks/discovery/disc_controller.py
@@ -955,6 +955,15 @@ Finance Database:
         )
 
         parser.add_argument(
+            "-mc",
+            "--marketcap",
+            default=["Large Cap"],
+            nargs="+",
+            dest="marketcap",
+            help="Specify the Equities selection based on Market Cap",
+        )
+
+        parser.add_argument(
             "-ie",
             "--include_exchanges",
             action="store_false",
@@ -991,6 +1000,7 @@ Finance Database:
             industry=ns_parser.industry,
             name=ns_parser.name,
             description=ns_parser.description,
+            marketcap=ns_parser.marketcap,
             include_exchanges=ns_parser.include_exchanges,
             amount=ns_parser.amount,
             options=ns_parser.options,

--- a/gamestonk_terminal/stocks/discovery/disc_controller.py
+++ b/gamestonk_terminal/stocks/discovery/disc_controller.py
@@ -955,7 +955,7 @@ Finance Database:
         )
 
         parser.add_argument(
-            "-mc",
+            "-m",
             "--marketcap",
             default=["Large"],
             choices=["Small", "Mid", "Large"],

--- a/gamestonk_terminal/stocks/discovery/disc_controller.py
+++ b/gamestonk_terminal/stocks/discovery/disc_controller.py
@@ -957,9 +957,11 @@ Finance Database:
         parser.add_argument(
             "-mc",
             "--marketcap",
-            default=["Large Cap"],
+            default=["Large"],
+            choices=["Small", "Mid", "Large"],
             nargs="+",
             dest="marketcap",
+            type=str.title,
             help="Specify the Equities selection based on Market Cap",
         )
 

--- a/gamestonk_terminal/stocks/discovery/financedatabase_view.py
+++ b/gamestonk_terminal/stocks/discovery/financedatabase_view.py
@@ -21,7 +21,7 @@ def show_equities(
 ):
     """
     Display a selection of Equities based on country, sector, industry, name and/or description filtered
-    by market cap. If no arguments are given, return the equities with the highest market cap.
+    by market cap. If no arguments are given, return equities categorized as Large Cap.
     [Source: Finance Database]
 
     Parameters
@@ -36,6 +36,8 @@ def show_equities(
         Search by name to find stocks matching the criteria.
     description : str
         Search by description to find stocks matching the criteria.
+    marketcap : str
+        Select stocks based on the market cap.
     amount : int
         Number of stocks to display, default is 10.
     include_exchanges: bool
@@ -67,13 +69,9 @@ def show_equities(
     if description is not None:
         data = fd.search_products(data, query=" ".join(description), search="summary")
     if marketcap is not None:
-        marketcap = " ".join(marketcap).title()
-        if marketcap not in ["Small Cap", "Mid Cap", "Large Cap"]:
-            raise ValueError(
-                f"Invalid choice ({marketcap}) for -mc/--marketcap. Choose from 'Small Cap', "
-                f"'Mid Cap' or 'Large Cap'."
-            )
-        data = fd.search_products(data, query=marketcap, search="market_cap")
+        data = fd.search_products(
+            data, query=f"{''.join(marketcap)} Cap", search="market_cap"
+        )
 
     tabulate_data = pd.DataFrame(data).T[
         [

--- a/website/content/stocks/discovery/fds/_index.md
+++ b/website/content/stocks/discovery/fds/_index.md
@@ -14,7 +14,9 @@ Source: https://github.com/JerBouma/FinanceDatabase
 * -i --industry: Specify the Equities selection based on an industry
 * -n --name: Specify the Equities selection based on the name
 * -d --description: Specify the Equities selection based on the description (not shown in table)
-* -ie --include_exchanges: If used, you also obtain Equities from different exchanges (a lot of data) 
+* -mc --marketcap: Specify the Equities selection based on Market Cap
+* -ie --include_exchanges: If used, you also obtain Equities from different exchanges (a lot of data)
 * -a --amount: Enter the number of Equities you wish to see in the Tabulate window
 * -o --options: Obtain the available options for country, sector and industry
+
 <img width="1400" alt="Feature Screeshot - fds" src="https://user-images.githubusercontent.com/85772166/140450303-ab41459b-2c8c-4115-9a44-226c120e8e67.png">

--- a/website/content/stocks/discovery/fds/_index.md
+++ b/website/content/stocks/discovery/fds/_index.md
@@ -1,8 +1,8 @@
 ```
 usage: fds [-c --country COUNTRY [COUNTRY ...]] [-s --sector SECTOR [SECTOR ...]]
         [-i --industry INDUSTRY [INDUSTRY ...]] [-n --name NAME [NAME ...]]
-        [-d --description DESCRIPTION [DESCRIPTION ...]] [-ie --include_exchanges] [-a --amount AMOUNT]
-        [-o --options {countries,sectors,industries}] [-h]
+        [-m --marketcap MARKETCAP {Small, Mid, Large}] [-d --description DESCRIPTION [DESCRIPTION ...]
+        [-ie --include_exchanges] [-a --amount AMOUNT] [-o --options {countries,sectors,industries}] [-h]
 ```
 Display a selection of Equities based on country, sector, industry, name and/or description filtered by market cap.
 If no arguments are given, return the equities with the highest market cap.
@@ -14,7 +14,7 @@ Source: https://github.com/JerBouma/FinanceDatabase
 * -i --industry: Specify the Equities selection based on an industry
 * -n --name: Specify the Equities selection based on the name
 * -d --description: Specify the Equities selection based on the description (not shown in table)
-* -mc --marketcap: Specify the Equities selection based on Market Cap
+* -m --marketcap: Specify the Equities selection based on Market Cap
 * -ie --include_exchanges: If used, you also obtain Equities from different exchanges (a lot of data)
 * -a --amount: Enter the number of Equities you wish to see in the Tabulate window
 * -o --options: Obtain the available options for country, sector and industry


### PR DESCRIPTION
I made a change in the Finance Database that categorises the Market Cap number to either Small Cap, Mid Cap or Large Cap. This is based on [this article](https://www.investopedia.com/investing/market-capitalization-defined/). Could have also added Nano Cap, Micro Cap and Mega Cap but I think for now this is fine and makes more sense.

![image](https://user-images.githubusercontent.com/46355364/141518005-e91ebe77-a56a-4b3b-9b28-c0095f6e67dd.png)