### PR TITLE
Remove payout ratio from key

### DIFF
--- a/gamestonk_terminal/stocks/fundamental_analysis/av_model.py
+++ b/gamestonk_terminal/stocks/fundamental_analysis/av_model.py
@@ -104,7 +104,6 @@ def get_key_metrics(ticker: str) -> pd.DataFrame:
             "PEG ratio",
             "Price to book ratio",
             "Return on equity TTM",
-            "Payout ratio",
             "Price to sales ratio TTM",
             "Dividend yield",
             "50 day moving average",


### PR DESCRIPTION
Addressed #939.

Not sure why, but "Payout ratio" was not in the list of what was pulled down from AV.