### PR TITLE
Update fa to account for suffix,  add load

### DIFF
--- a/gamestonk_terminal/stocks/stocks_controller.py
+++ b/gamestonk_terminal/stocks/stocks_controller.py
@@ -543,11 +543,7 @@ Market {('CLOSED', 'OPEN')[b_is_stock_market_open()]}
 
         from gamestonk_terminal.stocks.fundamental_analysis import fa_controller
 
-        ret = fa_controller.menu(
-            self.ticker,
-            self.start,
-            self.interval,
-        )
+        ret = fa_controller.menu(self.ticker, self.start, self.interval, self.suffix)
 
         if ret is False:
             self.print_help()


### PR DESCRIPTION
Another bug/improvement.  This PR addresses 2 things

1.  `load` was listed in the menu but not implemented.  Now implemented.
2. yahoo finance allows looking at fa stuff using the suffix convention (ie glxy.to).  I now pass through the suffix so that just the yahoo finance can be used.  As shown in screenshot, I add a disclaimer and dim the unusable functions.
<img width="709" alt="Screen Shot 2021-11-20 at 4 24 36 PM" src="https://user-images.githubusercontent.com/18151143/142741462-882e82fb-5a46-4615-8466-39f52a880718.png">


