### PR TITLE
Updating tests : workflows + pre-commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,9 +30,9 @@ jobs:
       - run: pip install types-pytz types-requests types-termcolor types-tabulate types-PyYAML types-python-dateutil
       - run: bandit -x ./tests -r . || true
       - run: black --check .
-      - run: codespell --ignore-words-list=ba,buil,coo,ether,hist,hsi,mape,navagation,operatio,pres,ser,yeld --quiet-level=2 --skip="./tests,.git,*.css,*.csv,*.html,*.ini,*.ipynb,*.js,*.json,*.lock,*.scss,*.txt,*.yaml"
+      - run: codespell --ignore-words-list=ba,buil,coo,ether,hist,hsi,mape,navagation,operatio,pres,ser,yeld --quiet-level=2 --skip=./tests,.git,*.css,*.csv,*.html,*.ini,*.ipynb,*.js,*.json,*.lock,*.scss,*.txt,*.yaml
       - run: flake8 . --count --ignore=E203,W503 --max-line-length=122 --show-source --statistics
-      - run: mypy --ignore-missing-imports --exclude '/setup\.py$' .
+      - run: mypy --ignore-missing-imports --exclude="/setup\.py$" .
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py
       - run: safety check
       - run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     rev: 'v0.812'
     hooks:
       - id: mypy
-        args: [ '--ignore-missing-imports',  '--exclude="/setup\.py$"', '.']
+        args: [ '--ignore-missing-imports',  '--exclude=/setup\.py$', '.']
   - repo: local
     hooks:
        - id: pylint

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,9 @@ repos:
     hooks:
       - id: check-yaml
       - id: end-of-file-fixer
+        exclude_types: [css, markdown, text, svg]
       - id: trailing-whitespace
+        exclude_types: [html, markdown, text]
       - id: check-merge-conflict
       - id: detect-private-key
   - repo: https://github.com/psf/black
@@ -21,12 +23,12 @@ repos:
     hooks:
       - id: codespell
         entry: codespell
-        args: [ '--ignore-words-list=ba,buil,coo,ether,hist,hsi,mape,navagation,operatio,pres,ser,yeld', '--quiet-level=2', '--skip="./tests,.git,*.css,*.csv,*.html,*.ini,*.ipynb,*.js,*.json,*.lock,*.scss,*.txt,*.yaml"' ]
+        args: [ '--ignore-words-list=ba,buil,coo,ether,hist,hsi,mape,navagation,operatio,pres,ser,yeld', '--quiet-level=2', '--skip=./tests,.git,*.css,*.csv,*.html,*.ini,*.ipynb,*.js,*.json,*.lock,*.scss,*.txt,*.yaml' ]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: 'v0.812'
     hooks:
       - id: mypy
-        args: [ '--ignore-missing-imports',  '--exclude "/setup\.py$"', '.']
+        args: [ '--ignore-missing-imports',  '--exclude="/setup\.py$"', '.']
   - repo: local
     hooks:
        - id: pylint


### PR DESCRIPTION
**Reason**
- By default `pre-commit run` only checks on staged files.

Executing `pre-commit run --all-files` : there are some unwanted behaviors.

This `Pull Request` is to allow running `pre-commit` on all the files of the project.
- Fixing a bug on `mypy`

**Consequences**
- `trailing-whitespace` and `end-of-file-fixer` : excluding file types
- `mypy` properly exclude `setup.py` files