### PR TITLE
Update pre-commit hooks to be up to date for linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,11 +10,11 @@ repos:
       - id: check-merge-conflict
       - id: detect-private-key
   - repo: https://github.com/psf/black
-    rev: 21.9b0
+    rev: 21.11b1
     hooks:
       - id: black
   - repo: https://github.com/pycqa/flake8
-    rev: 3.9.2
+    rev: 4.0.1
     hooks:
       - id: flake8
         entry: flake8 --ignore=E203,W503 --max-line-length=122
@@ -25,7 +25,7 @@ repos:
         entry: codespell
         args: [ '--ignore-words-list=ba,buil,coo,ether,hist,hsi,mape,navagation,operatio,pres,ser,yeld', '--quiet-level=2', '--skip=./tests,.git,*.css,*.csv,*.html,*.ini,*.ipynb,*.js,*.json,*.lock,*.scss,*.txt,*.yaml' ]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.812'
+    rev: 'v0.910-1'
     hooks:
       - id: mypy
         args: [ '--ignore-missing-imports',  '--exclude=/setup\.py$', '.']
@@ -43,7 +43,7 @@ repos:
         args: [ '--baseline', '.secrets.baseline', '--exclude-files', 'tests/cassettes/*' ]
         exclude: package.lock.json
   - repo: https://github.com/asottile/pyupgrade
-    rev: v2.23.3
+    rev: v2.29.1
     hooks:
       - id: pyupgrade
         args: [ --py36-plus ]


### PR DESCRIPTION
This upgrades the pre-commits for

- black
- mypy
- flake8
- pyupgrade

Note this does not fix the local mypy hook issue (even though there is an init file): 
```
gamestonk_terminal/common/prediction_techniques/regression_model.py: error: Duplicate module named "gamestonk_terminal.common.prediction_techniques.regression_model" (also at "./gamestonk_terminal/common/prediction_techniques/regression_model.py")
gamestonk_terminal/common/prediction_techniques/regression_model.py: note: Are you missing an __init__.py? Alternatively, consider using --exclude to avoid checking one of them.
```