### PR TITLE
(Finally) add prediction abilities to crypto

### DIFF
--- a/gamestonk_terminal/common/prediction_techniques/knn_view.py
+++ b/gamestonk_terminal/common/prediction_techniques/knn_view.py
@@ -14,6 +14,8 @@ from gamestonk_terminal.common.prediction_techniques import knn_model
 
 register_matplotlib_converters()
 
+# pylint:disable=too-many-arguments
+
 
 def display_k_nearest_neighbors(
     ticker: str,
@@ -24,6 +26,7 @@ def display_k_nearest_neighbors(
     test_size: float,
     end_date: str = "",
     no_shuffle: bool = True,
+    time_res: str = "",
 ):
     """Display predictions using knn
 
@@ -45,6 +48,8 @@ def display_k_nearest_neighbors(
         End date for backtesting, by default ""
     no_shuffle : bool, optional
         Flag to shuffle data randomly, by default True
+    time_res : str
+        Resolution for data, allowing for predicting outside of standard market days
     """
     (
         forecast_data_df,
@@ -55,10 +60,15 @@ def display_k_nearest_neighbors(
     ) = knn_model.get_knn_model_data(
         data, n_input_days, n_predict_days, n_neighbors, test_size, end_date, no_shuffle
     )
+
     if forecast_data_df.empty:
         print("Issue performing data prep and prediction")
         return
 
+    if time_res:
+        forecast_data_df.index = pd.date_range(
+            data.index[-1], periods=n_predict_days + 1, freq=time_res
+        )[1:]
     print_pretty_prediction(forecast_data_df[0], data.values[-1])
     plot_data_predictions(
         data,
@@ -69,5 +79,6 @@ def display_k_nearest_neighbors(
         f"KNN Model with {n_neighbors} Neighbors on {ticker}",
         forecast_data_df,
         1,
+        time_res,
     )
     print("")

--- a/gamestonk_terminal/common/prediction_techniques/mc_view.py
+++ b/gamestonk_terminal/common/prediction_techniques/mc_view.py
@@ -26,6 +26,7 @@ def display_mc_forecast(
     n_sims: int,
     use_log=True,
     export: str = "",
+    time_res: str = "",
 ):
     """Display monte carlo forecasting
 
@@ -41,9 +42,16 @@ def display_mc_forecast(
         Flag to use lognormal, by default True
     export: str
         Format to export data
+    time_res : str
+        Resolution for data, allowing for predicting outside of standard market days
     """
     predicted_values = mc_model.get_mc_brownian(data, n_future, n_sims, use_log)
-    future_index = get_next_stock_market_days(data.index[-1], n_next_days=n_future)  # type: ignore
+    if not time_res or time_res == "1D":
+        future_index = get_next_stock_market_days(data.index[-1], n_next_days=n_future)  # type: ignore
+    else:
+        future_index = future_index = pd.date_range(
+            data.index[-1], periods=n_future + 1, freq=time_res
+        )[1:]
     dateFmt = mdates.DateFormatter("%m/%d/%Y")
 
     fig, ax = plt.subplots(1, 2, figsize=plot_autoscale(), dpi=PLOT_DPI)
@@ -57,9 +65,11 @@ def display_mc_forecast(
 
     sns.histplot(predicted_values[-1, :], ax=ax[1], kde=True)
     ax[1].set_xlabel("Price")
-    ax[1].set_title(f"Distribution of data after {n_future} days.")
+    ax[1].axvline(x=data.values[-1], c="k", label="Last Value", lw=3, ls="-")
+    ax[1].set_title(f"Distribution of final values after {n_future} steps.")
     ax[1].set_xlim(np.min(predicted_values[-1, :]), np.max(predicted_values[-1, :]))
     ax[1].grid("on")
+    ax[1].legend()
 
     fig.tight_layout(pad=2)
 

--- a/gamestonk_terminal/common/prediction_techniques/mc_view.py
+++ b/gamestonk_terminal/common/prediction_techniques/mc_view.py
@@ -49,9 +49,8 @@ def display_mc_forecast(
     if not time_res or time_res == "1D":
         future_index = get_next_stock_market_days(data.index[-1], n_next_days=n_future)  # type: ignore
     else:
-        future_index = future_index = pd.date_range(
-            data.index[-1], periods=n_future + 1, freq=time_res
-        )[1:]
+        future_index = pd.date_range(data.index[-1], periods=n_future + 1, freq=time_res)[1:]  # type: ignore
+
     dateFmt = mdates.DateFormatter("%m/%d/%Y")
 
     fig, ax = plt.subplots(1, 2, figsize=plot_autoscale(), dpi=PLOT_DPI)
@@ -65,7 +64,7 @@ def display_mc_forecast(
 
     sns.histplot(predicted_values[-1, :], ax=ax[1], kde=True)
     ax[1].set_xlabel("Price")
-    ax[1].axvline(x=data.values[-1], c="k", label="Last Value", lw=3, ls="-")
+    ax[1].axvline(x=data.values[-1], c="k", label="Last Value", lw=3, ls="-")  # type: ignore
     ax[1].set_title(f"Distribution of final values after {n_future} steps.")
     ax[1].set_xlim(np.min(predicted_values[-1, :]), np.max(predicted_values[-1, :]))
     ax[1].grid("on")

--- a/gamestonk_terminal/common/prediction_techniques/neural_networks_view.py
+++ b/gamestonk_terminal/common/prediction_techniques/neural_networks_view.py
@@ -25,6 +25,7 @@ def display_mlp(
     test_size: float,
     n_loops: int,
     no_shuffle: bool,
+    time_res: str = "",
 ):
     """Display trained MLP model
 
@@ -50,6 +51,8 @@ def display_mlp(
         Number of loops to perform for model
     no_shuffle : bool
         Flag to not randomly shuffle data
+    time_res : str
+        Resolution for data, allowing for predicting outside of standard market days
     """
     (
         forecast_data_df,
@@ -69,6 +72,11 @@ def display_mlp(
         no_shuffle,
     )
 
+    if time_res:
+        forecast_data_df.index = pd.date_range(
+            data.index[-1], periods=n_predict_days + 1, freq=time_res
+        )[1:]
+
     if n_loops > 1:
         forecast_data_df["Median"] = forecast_data_df.median(axis=1)
         print_pretty_prediction(forecast_data_df["Median"], data.values[-1])
@@ -83,6 +91,7 @@ def display_mlp(
         f"MLP Model on {dataset}",
         forecast_data_df,
         n_loops,
+        time_res,
     )
     print("")
 
@@ -98,6 +107,7 @@ def display_rnn(
     test_size: float,
     n_loops: int,
     no_shuffle: bool,
+    time_res: str = "",
 ):
     """Display trained RNN model
 
@@ -123,6 +133,8 @@ def display_rnn(
         Number of loops to perform for model
     no_shuffle : bool
         Flag to not randomly shuffle data
+    time_res : str
+        Resolution for data, allowing for predicting outside of standard market days
     """
 
     (
@@ -142,7 +154,10 @@ def display_rnn(
         n_loops,
         no_shuffle,
     )
-
+    if time_res:
+        forecast_data_df.index = pd.date_range(
+            data.index[-1], periods=n_predict_days + 1, freq=time_res
+        )[1:]
     if n_loops > 1:
         forecast_data_df["Median"] = forecast_data_df.median(axis=1)
         print_pretty_prediction(forecast_data_df["Median"], data.values[-1])
@@ -157,6 +172,7 @@ def display_rnn(
         f"RNN Model on {dataset}",
         forecast_data_df,
         n_loops,
+        time_res,
     )
     print("")
 
@@ -172,6 +188,7 @@ def display_lstm(
     test_size: float,
     n_loops: int,
     no_shuffle: bool,
+    time_res: str = "",
 ):
     """Display trained LSTM model
 
@@ -197,6 +214,8 @@ def display_lstm(
         Number of loops to perform for model
     no_shuffle : bool
         Flag to not randomly shuffle data
+    time_res : str
+        Resolution for data, allowing for predicting outside of standard market days
     """
 
     (
@@ -216,7 +235,10 @@ def display_lstm(
         n_loops,
         no_shuffle,
     )
-
+    if time_res:
+        forecast_data_df.index = pd.date_range(
+            data.index[-1], periods=n_predict_days + 1, freq=time_res
+        )[1:]
     if n_loops > 1:
         forecast_data_df["Median"] = forecast_data_df.median(axis=1)
         print_pretty_prediction(forecast_data_df["Median"], data.values[-1])
@@ -231,6 +253,7 @@ def display_lstm(
         f"LSTM Model on {dataset}",
         forecast_data_df,
         n_loops,
+        time_res,
     )
     print("")
 
@@ -246,6 +269,7 @@ def display_conv1d(
     test_size: float,
     n_loops: int,
     no_shuffle: bool,
+    time_res: str = "",
 ):
     """Display trained Conv1D model
 
@@ -271,6 +295,8 @@ def display_conv1d(
         Number of loops to perform for model
     no_shuffle : bool
         Flag to not randomly shuffle data
+    time_res : str
+        Resolution for data, allowing for predicting outside of standard market days
     """
 
     (
@@ -290,7 +316,10 @@ def display_conv1d(
         n_loops,
         no_shuffle,
     )
-
+    if time_res:
+        forecast_data_df.index = pd.date_range(
+            data.index[-1], periods=n_predict_days + 1, freq=time_res
+        )[1:]
     if n_loops > 1:
         forecast_data_df["Median"] = forecast_data_df.median(axis=1)
         print_pretty_prediction(forecast_data_df["Median"], data.values[-1])
@@ -305,5 +334,6 @@ def display_conv1d(
         f"Conv1D Model on {dataset}",
         forecast_data_df,
         n_loops,
+        time_res,
     )
     print("")

--- a/gamestonk_terminal/common/prediction_techniques/pred_helper.py
+++ b/gamestonk_terminal/common/prediction_techniques/pred_helper.py
@@ -396,9 +396,21 @@ def forecast(
     return df_future
 
 
+# pylint:disable=too-many-arguments
+
+
 def plot_data_predictions(
-    data, preds, y_valid, y_dates_valid, scaler, title, forecast_data, n_loops
+    data,
+    preds,
+    y_valid,
+    y_dates_valid,
+    scaler,
+    title,
+    forecast_data,
+    n_loops,
+    time_str: str = "",
 ):
+    """Plots data predictions for the different ML techniques"""
 
     plt.figure(figsize=plot_autoscale(), dpi=PLOT_DPI)
     plt.plot(
@@ -461,15 +473,10 @@ def plot_data_predictions(
         color="k",
         alpha=0.2,
     )
-    plt.axvspan(
-        forecast_data.index[0] - timedelta(days=1),
-        forecast_data.index[-1],
-        facecolor="tab:orange",
-        alpha=0.2,
-    )
+
     _, _, ymin, ymax = plt.axis()
     plt.vlines(
-        forecast_data.index[0] - timedelta(days=1),
+        forecast_data.index[0],
         ymin,
         ymax,
         colors="k",
@@ -500,8 +507,26 @@ def plot_data_predictions(
             color="c",
             alpha=0.3,
         )
+    # Subtracting 1 day only works nicely for daily data.  For now if not daily, then start line on last point
+    if not time_str or time_str == "1D":
+        plt.axvspan(
+            forecast_data.index[0] - timedelta(days=1),
+            forecast_data.index[-1],
+            facecolor="tab:orange",
+            alpha=0.2,
+        )
+        plt.xlim(data.index[0], forecast_data.index[-1] + timedelta(days=1))
+
+    else:
+        plt.axvspan(
+            forecast_data.index[0],
+            forecast_data.index[-1],
+            facecolor="tab:orange",
+            alpha=0.2,
+        )
+        plt.xlim(data.index[0], forecast_data.index[-1])
+
     plt.legend(loc=0)
-    plt.xlim(data.index[0], forecast_data.index[-1] + timedelta(days=1))
     plt.xlabel("Time")
     plt.ylabel("Value")
     plt.grid(b=True, which="major", color="#666666", linestyle="-")

--- a/gamestonk_terminal/cryptocurrency/crypto_controller.py
+++ b/gamestonk_terminal/cryptocurrency/crypto_controller.py
@@ -756,7 +756,7 @@ What do you want to do?
 
             pred = pred_controller.menu(
                 self.current_coin,
-                c_help.load_cg_coin_data(self.current_coin, "USD", 30, "1H"),
+                c_help.load_cg_coin_data(self.current_coin, "USD", 365, "1D"),
             )
             if pred is False:
                 self.print_help()

--- a/gamestonk_terminal/cryptocurrency/crypto_controller.py
+++ b/gamestonk_terminal/cryptocurrency/crypto_controller.py
@@ -120,7 +120,7 @@ What do you want to do?
 >   ov          overview of the cryptocurrencies,       e.g.: market cap, DeFi, latest news, top exchanges, stables{dim}
 >   dd          due-diligence for loaded coin,          e.g.: coin information, social media, market stats
 >   ta          technical analysis for loaded coin,     e.g.: ema, macd, rsi, adx, bbands, obv
->   pred        prediction techniques
+>   pred        prediction techniques                   e.g.: regression, arima, rnn, lstm, conv1d, monte carlo
 {Style.RESET_ALL if not self.current_coin else ""}
 >   onchain     information on different blockchains,   e.g.: eth gas fees, active asset addresses, whale alerts
 >   defi        decentralized finance information,      e.g.: dpi, llama, tvl, lending, borrow, funding
@@ -743,6 +743,12 @@ What do you want to do?
 
     def call_pred(self, _):
         """Process pred command"""
+        if not self.current_coin:
+            print(
+                "No coin loaded.  Please use `load <coin>` to access prediction menu\n."
+            )
+            return
+
         if self.source != "cg":
             print("Currently only supports CoinGecko source.\n")
             return

--- a/gamestonk_terminal/cryptocurrency/crypto_controller.py
+++ b/gamestonk_terminal/cryptocurrency/crypto_controller.py
@@ -61,7 +61,7 @@ class CryptoController:
         "find",
     ]
 
-    CHOICES_MENUS = ["ta", "dd", "ov", "disc", "onchain", "defi", "nft"]
+    CHOICES_MENUS = ["ta", "dd", "ov", "disc", "onchain", "defi", "nft", "pred"]
 
     SOURCES = {
         "bin": "Binance",
@@ -120,6 +120,7 @@ What do you want to do?
 >   ov          overview of the cryptocurrencies,       e.g.: market cap, DeFi, latest news, top exchanges, stables{dim}
 >   dd          due-diligence for loaded coin,          e.g.: coin information, social media, market stats
 >   ta          technical analysis for loaded coin,     e.g.: ema, macd, rsi, adx, bbands, obv
+>   pred        prediction techniques
 {Style.RESET_ALL if not self.current_coin else ""}
 >   onchain     information on different blockchains,   e.g.: eth gas fees, active asset addresses, whale alerts
 >   defi        decentralized finance information,      e.g.: dpi, llama, tvl, lending, borrow, funding
@@ -732,6 +733,32 @@ What do you want to do?
 
             dd = dd_controller.menu(self.current_coin, self.source, self.symbol)
             if dd is False:
+                self.print_help()
+            else:
+                return True
+        else:
+            print(
+                "No coin selected. Use 'load' to load the coin you want to look at.\n"
+            )
+
+    def call_pred(self, _):
+        """Process pred command"""
+        if self.source != "cg":
+            print("Currently only supports CoinGecko source.\n")
+            return
+        if self.current_coin:
+            from gamestonk_terminal.cryptocurrency.prediction_techniques import (
+                pred_controller,
+            )
+            from gamestonk_terminal.cryptocurrency import (
+                cryptocurrency_helpers as c_help,
+            )
+
+            pred = pred_controller.menu(
+                self.current_coin,
+                c_help.load_cg_coin_data(self.current_coin, "USD", 30, "1H"),
+            )
+            if pred is False:
                 self.print_help()
             else:
                 return True

--- a/gamestonk_terminal/cryptocurrency/cryptocurrency_helpers.py
+++ b/gamestonk_terminal/cryptocurrency/cryptocurrency_helpers.py
@@ -69,10 +69,9 @@ def load_cg_coin_data(
     df["time"] = pd.to_datetime(df.time, unit="ms")
     df = df.set_index("time")
     if days > 90:
-        df = df.resample(sampling).ohlc()
-        df.columns = ["Open", "High", "Low", "Close"]
-        return df
-    df.columns = ["Close"]
+        sampling = "1D"
+    df = df.resample(sampling).ohlc()
+    df.columns = ["Open", "High", "Low", "Close"]
     return df
 
 

--- a/gamestonk_terminal/cryptocurrency/prediction_techniques/pred_controller.py
+++ b/gamestonk_terminal/cryptocurrency/prediction_techniques/pred_controller.py
@@ -38,7 +38,7 @@ class PredictionTechniquesController:
     """Prediction Techniques Controller class"""
 
     # Command choices
-    CHOICES = ["cls", "?", "help", "q", "quit", "load", "pick", "reload"]
+    CHOICES = ["cls", "?", "help", "q", "quit", "load", "pick"]
 
     CHOICES_MODELS = [
         "ets",
@@ -66,6 +66,7 @@ class PredictionTechniquesController:
 
         self.data = data
         self.coin = coin
+        self.resolution = "1D"
         self.target = "Close"
         self.pred_parser = argparse.ArgumentParser(add_help=False, prog="pred")
         self.pred_parser.add_argument(
@@ -188,6 +189,8 @@ Models:
             help="How often to resample data.",
             choices=["1H", "3H", "6H", "1D"],
         )
+        if other_args and "-" not in other_args[0]:
+            other_args.insert(0, "-c")
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if not ns_parser:
             return
@@ -198,6 +201,7 @@ Models:
             ns_parser.coin, ns_parser.currency, ns_parser.days, ns_parser.resolution
         )
         res = ns_parser.resolution if ns_parser.days < 90 else "1D"
+        self.resolution = res
         print(
             f"{ns_parser.days} Days of {self.coin} vs {ns_parser.currency} loaded with {res} resolution.\n"
         )
@@ -329,6 +333,7 @@ Models:
             seasonal_periods=ns_parser.seasonal_periods,
             s_end_date=ns_parser.s_end_date,
             export=ns_parser.export,
+            time_res=self.resolution,
         )
 
     @try_except
@@ -417,6 +422,7 @@ Models:
             test_size=ns_parser.valid_split,
             end_date=ns_parser.s_end_date,
             no_shuffle=ns_parser.no_shuffle,
+            time_res=self.resolution,
         )
 
     @try_except
@@ -515,6 +521,7 @@ Models:
             n_jumps=ns_parser.n_jumps,
             s_end_date=ns_parser.s_end_date,
             export=ns_parser.export,
+            time_res=self.resolution,
         )
 
     @try_except
@@ -622,6 +629,7 @@ Models:
             results=ns_parser.b_results,
             s_end_date=ns_parser.s_end_date,
             export=ns_parser.export,
+            time_res=self.resolution,
         )
 
     @try_except
@@ -647,6 +655,7 @@ Models:
                 test_size=ns_parser.valid_split,
                 n_loops=ns_parser.n_loops,
                 no_shuffle=ns_parser.no_shuffle,
+                time_res=self.resolution,
             )
         except Exception as e:
             print(e, "\n")
@@ -676,6 +685,7 @@ Models:
                 test_size=ns_parser.valid_split,
                 n_loops=ns_parser.n_loops,
                 no_shuffle=ns_parser.no_shuffle,
+                time_res=self.resolution,
             )
 
         except Exception as e:
@@ -705,6 +715,7 @@ Models:
                 test_size=ns_parser.valid_split,
                 n_loops=ns_parser.n_loops,
                 no_shuffle=ns_parser.no_shuffle,
+                time_res=self.resolution,
             )
 
         except Exception as e:
@@ -735,6 +746,7 @@ Models:
                 test_size=ns_parser.valid_split,
                 n_loops=ns_parser.n_loops,
                 no_shuffle=ns_parser.no_shuffle,
+                time_res=self.resolution,
             )
 
         except Exception as e:
@@ -792,6 +804,7 @@ Models:
             n_sims=ns_parser.n_sims,
             use_log=ns_parser.dist == "lognormal",
             export=ns_parser.export,
+            time_res=self.resolution,
         )
 
 

--- a/gamestonk_terminal/cryptocurrency/prediction_techniques/pred_controller.py
+++ b/gamestonk_terminal/cryptocurrency/prediction_techniques/pred_controller.py
@@ -1,0 +1,778 @@
+"""Crypto Prediction Controller"""
+__docformat__ = "numpy"
+
+import argparse
+import difflib
+from typing import List
+
+import pandas as pd
+import numpy as np
+import matplotlib.pyplot as plt
+from prompt_toolkit.completion import NestedCompleter
+
+from gamestonk_terminal import feature_flags as gtff
+from gamestonk_terminal.helper_funcs import (
+    get_flair,
+    parse_known_args_and_warn,
+    check_positive,
+    valid_date,
+    get_next_stock_market_days,
+    EXPORT_ONLY_FIGURES_ALLOWED,
+    try_except,
+    system_clear,
+)
+from gamestonk_terminal.menu import session
+from gamestonk_terminal.common.prediction_techniques import (
+    arima_view,
+    ets_view,
+    knn_view,
+    neural_networks_view,
+    regression_view,
+    pred_helper,
+    mc_view,
+)
+
+
+class PredictionTechniquesController:
+    """Prediction Techniques Controller class"""
+
+    # Command choices
+    CHOICES = ["cls", "?", "help", "q", "quit", "load", "pick", "resample"]
+
+    CHOICES_MODELS = [
+        "ets",
+        "knn",
+        "regression",
+        "arima",
+        "mlp",
+        "rnn",
+        "lstm",
+        "conv1d",
+        "mc",
+    ]
+    CHOICES += CHOICES_MODELS
+    sampling_map = {"H": "Hour", "D": "Day"}
+
+    def __init__(
+        self,
+        coin: str,
+        data: pd.DataFrame,
+    ):
+        """Constructor"""
+        data["Returns"] = data["Close"].pct_change()
+        data["LogRet"] = np.log(data["Close"]) - np.log(data["Close"].shift(1))
+        data = data.dropna()
+
+        self.data = data
+        self.coin = coin
+        self.target = "Close"
+        self.current_sampling = "1H"
+        self.days_of_data = 30
+        self.pred_parser = argparse.ArgumentParser(add_help=False, prog="pred")
+        self.pred_parser.add_argument(
+            "cmd",
+            choices=self.CHOICES,
+        )
+
+    def print_help(self):
+        """Print help"""
+
+        help_string = f"""
+Prediction Techniques:
+    cls         clear screen
+    ?/help      show this menu again
+    q           quit this menu, and shows back to main menu
+    quit        quit to abandon program
+    load        load new ticker
+    pick        pick new target variable
+
+Coin Loaded: {self.coin}
+Target Column: {self.target}
+
+
+Models:
+    ets         exponential smoothing (e.g. Holt-Winters)
+    knn         k-Nearest Neighbors
+    regression  polynomial regression
+    arima       autoregressive integrated moving average
+    mlp         MultiLayer Perceptron
+    rnn         Recurrent Neural Network
+    lstm        Long-Short Term Memory
+    conv1d      1D Convolutional Neural Network
+    mc          Monte-Carlo simulations
+        """
+        print(help_string)
+
+    def switch(self, an_input: str):
+        """Process and dispatch input
+
+        Returns
+        -------
+        True, False or None
+            False - quit the menu
+            True - quit the program
+            None - continue in the menu
+        """
+
+        # Empty command
+        if not an_input:
+            print("")
+            return None
+
+        (known_args, other_args) = self.pred_parser.parse_known_args(an_input.split())
+
+        # Help menu again
+        if known_args.cmd == "?":
+            self.print_help()
+            return None
+
+        # Clear screen
+        if known_args.cmd == "cls":
+            system_clear()
+            return None
+
+        return getattr(
+            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+        )(other_args)
+
+    def call_help(self, _):
+        """Process Help command"""
+        self.print_help()
+
+    def call_q(self, _):
+        """Process Q command - quit the menu"""
+        return False
+
+    def call_quit(self, _):
+        """Process Quit command - quit the program"""
+        return True
+
+    @try_except
+    def call_pick(self, other_args: List[str]):
+        """Process pick command"""
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            add_help=False,
+            prog="pick",
+            description="""
+                Change target variable
+            """,
+        )
+        parser.add_argument(
+            "-t",
+            "--target",
+            dest="target",
+            choices=list(self.data.columns),
+            help="Select variable to analyze",
+        )
+        if other_args and "-t" not in other_args and "-h" not in other_args:
+            other_args.insert(0, "-t")
+
+        ns_parser = parse_known_args_and_warn(parser, other_args)
+        if not ns_parser:
+            return
+        self.target = ns_parser.target
+        print("")
+
+    @try_except
+    def call_ets(self, other_args: List[str]):
+        """Process ets command"""
+        parser = argparse.ArgumentParser(
+            add_help=False,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            prog="ets",
+            description="""
+                Exponential Smoothing, see https://otexts.com/fpp2/taxonomy.html
+
+                Trend='N',  Seasonal='N': Simple Exponential Smoothing
+                Trend='N',  Seasonal='A': Exponential Smoothing
+                Trend='N',  Seasonal='M': Exponential Smoothing
+                Trend='A',  Seasonal='N': Holt’s linear method
+                Trend='A',  Seasonal='A': Additive Holt-Winters’ method
+                Trend='A',  Seasonal='M': Multiplicative Holt-Winters’ method
+                Trend='Ad', Seasonal='N': Additive damped trend method
+                Trend='Ad', Seasonal='A': Exponential Smoothing
+                Trend='Ad', Seasonal='M': Holt-Winters’ damped method
+                Trend component: N: None, A: Additive, Ad: Additive Damped
+                Seasonality component: N: None, A: Additive, M: Multiplicative
+            """,
+        )
+        parser.add_argument(
+            "-d",
+            "--days",
+            action="store",
+            dest="n_days",
+            type=check_positive,
+            default=5,
+            help="prediction days.",
+        )
+        parser.add_argument(
+            "-t",
+            "--trend",
+            action="store",
+            dest="trend",
+            choices=["N", "A", "Ad"],
+            default="N",
+            help="Trend component: N: None, A: Additive, Ad: Additive Damped.",
+        )
+        parser.add_argument(
+            "-s",
+            "--seasonal",
+            action="store",
+            dest="seasonal",
+            choices=["N", "A", "M"],
+            default="N",
+            help="Seasonality component: N: None, A: Additive, M: Multiplicative.",
+        )
+        parser.add_argument(
+            "-p",
+            "--periods",
+            action="store",
+            dest="seasonal_periods",
+            type=check_positive,
+            default=5,
+            help="Seasonal periods.",
+        )
+        parser.add_argument(
+            "-e",
+            "--end",
+            action="store",
+            type=valid_date,
+            dest="s_end_date",
+            default=None,
+            help="The end date (format YYYY-MM-DD) to select - Backtesting",
+        )
+        ns_parser = parse_known_args_and_warn(
+            parser, other_args, export_allowed=EXPORT_ONLY_FIGURES_ALLOWED
+        )
+        if not ns_parser:
+            return
+
+        if ns_parser.s_end_date:
+
+            if ns_parser.s_end_date < self.data.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if ns_parser.s_end_date < get_next_stock_market_days(
+                last_stock_day=self.data.index[0],
+                n_next_days=5 + ns_parser.n_days,
+            )[-1]:
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+        ets_view.display_exponential_smoothing(
+            ticker=self.coin,
+            values=self.data[self.target],
+            n_predict=ns_parser.n_days,
+            trend=ns_parser.trend,
+            seasonal=ns_parser.seasonal,
+            seasonal_periods=ns_parser.seasonal_periods,
+            s_end_date=ns_parser.s_end_date,
+            export=ns_parser.export,
+        )
+
+    @try_except
+    def call_knn(self, other_args: List[str]):
+        """Process knn command"""
+        parser = argparse.ArgumentParser(
+            add_help=False,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            prog="knn",
+            description="""
+                K nearest neighbors is a simple algorithm that stores all
+                available cases and predict the numerical target based on a similarity measure
+                (e.g. distance functions).
+            """,
+        )
+        parser.add_argument(
+            "-i",
+            "--input",
+            action="store",
+            dest="n_inputs",
+            type=check_positive,
+            default=40,
+            help="number of days to use as input for prediction.",
+        )
+        parser.add_argument(
+            "-d",
+            "--days",
+            action="store",
+            dest="n_days",
+            type=check_positive,
+            default=5,
+            help="prediction days.",
+        )
+        parser.add_argument(
+            "-j",
+            "--jumps",
+            action="store",
+            dest="n_jumps",
+            type=check_positive,
+            default=1,
+            help="number of jumps in training data.",
+        )
+        parser.add_argument(
+            "-n",
+            "--neighbors",
+            action="store",
+            dest="n_neighbors",
+            type=check_positive,
+            default=20,
+            help="number of neighbors to use on the algorithm.",
+        )
+        parser.add_argument(
+            "-e",
+            "--end",
+            action="store",
+            type=valid_date,
+            dest="s_end_date",
+            default=None,
+            help="The end date (format YYYY-MM-DD) to select for testing",
+        )
+        parser.add_argument(
+            "-t",
+            "--test_size",
+            default=0.2,
+            dest="valid_split",
+            type=float,
+            help="Percentage of data to validate in sample",
+        )
+        parser.add_argument(
+            "--no_shuffle",
+            action="store_false",
+            dest="no_shuffle",
+            default=True,
+            help="Specify if shuffling validation inputs.",
+        )
+        ns_parser = parse_known_args_and_warn(parser, other_args)
+        if not ns_parser:
+            return
+
+        knn_view.display_k_nearest_neighbors(
+            ticker=self.coin,
+            data=self.data[self.target],
+            n_neighbors=ns_parser.n_neighbors,
+            n_input_days=ns_parser.n_inputs,
+            n_predict_days=ns_parser.n_days,
+            test_size=ns_parser.valid_split,
+            end_date=ns_parser.s_end_date,
+            no_shuffle=ns_parser.no_shuffle,
+        )
+
+    @try_except
+    def call_regression(self, other_args: List[str]):
+        """Process linear command"""
+        parser = argparse.ArgumentParser(
+            add_help=False,
+            prog="regression",
+            description="""
+                Regression attempts to model the relationship between
+                two variables by fitting a linear/quadratic/cubic/other equation to
+                observed data. One variable is considered to be an explanatory variable,
+                and the other is considered to be a dependent variable.
+            """,
+        )
+
+        parser.add_argument(
+            "-i",
+            "--input",
+            action="store",
+            dest="n_inputs",
+            type=check_positive,
+            default=40,
+            help="number of days to use for prediction.",
+        )
+        parser.add_argument(
+            "-d",
+            "--days",
+            action="store",
+            dest="n_days",
+            type=check_positive,
+            default=5,
+            help="prediction days.",
+        )
+        parser.add_argument(
+            "-j",
+            "--jumps",
+            action="store",
+            dest="n_jumps",
+            type=check_positive,
+            default=1,
+            help="number of jumps in training data.",
+        )
+        parser.add_argument(
+            "-e",
+            "--end",
+            action="store",
+            type=valid_date,
+            dest="s_end_date",
+            default=None,
+            help="The end date (format YYYY-MM-DD) to select - Backtesting",
+        )
+        parser.add_argument(
+            "-p",
+            "--polynomial",
+            action="store",
+            dest="n_polynomial",
+            type=check_positive,
+            default=1,
+            help="polynomial associated with regression.",
+        )
+        if (
+            other_args
+            and "-h" not in other_args
+            and ("-p" not in other_args or "--polynomial" not in other_args)
+        ):
+            other_args.insert(0, "-p")
+        ns_parser = parse_known_args_and_warn(
+            parser, other_args, export_allowed=EXPORT_ONLY_FIGURES_ALLOWED
+        )
+        if not ns_parser:
+            return
+        # BACKTESTING CHECK
+        if ns_parser.s_end_date:
+            if ns_parser.s_end_date < self.data.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if ns_parser.s_end_date < get_next_stock_market_days(
+                last_stock_day=self.data.index[0],
+                n_next_days=5 + ns_parser.n_days,
+            )[-1]:
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+        regression_view.display_regression(
+            dataset=self.coin,
+            values=self.data[self.target],
+            poly_order=ns_parser.n_polynomial,
+            n_input=ns_parser.n_inputs,
+            n_predict=ns_parser.n_days,
+            n_jumps=ns_parser.n_jumps,
+            s_end_date=ns_parser.s_end_date,
+            export=ns_parser.export,
+        )
+
+    @try_except
+    def call_arima(self, other_args: List[str]):
+        """Process arima command"""
+        parser = argparse.ArgumentParser(
+            add_help=False,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            prog="arima",
+            description="""
+                In statistics and econometrics, and in particular in time series analysis, an
+                autoregressive integrated moving average (ARIMA) model is a generalization of an
+                autoregressive moving average (ARMA) model. Both of these models are fitted to time
+                series data either to better understand the data or to predict future points in the
+                series (forecasting). ARIMA(p,d,q) where parameters p, d, and q are non-negative
+                integers, p is the order (number of time lags) of the autoregressive model, d is the
+                degree of differencing (the number of times the data have had past values subtracted),
+                and q is the order of the moving-average model.
+            """,
+        )
+        parser.add_argument(
+            "-d",
+            "--days",
+            action="store",
+            dest="n_days",
+            type=check_positive,
+            default=5,
+            help="prediction days.",
+        )
+        parser.add_argument(
+            "-i",
+            "--ic",
+            action="store",
+            dest="s_ic",
+            type=str,
+            default="aic",
+            choices=["aic", "aicc", "bic", "hqic", "oob"],
+            help="information criteria.",
+        )
+        parser.add_argument(
+            "-s",
+            "--seasonal",
+            action="store_true",
+            default=False,
+            dest="b_seasonal",
+            help="Use weekly seasonal data.",
+        )
+        parser.add_argument(
+            "-o",
+            "--order",
+            action="store",
+            dest="s_order",
+            default="",
+            type=str,
+            help="arima model order (p,d,q) in format: p,d,q.",
+        )
+        parser.add_argument(
+            "-r",
+            "--results",
+            action="store_true",
+            dest="b_results",
+            default=False,
+            help="results about ARIMA summary flag.",
+        )
+        parser.add_argument(
+            "-e",
+            "--end",
+            action="store",
+            type=valid_date,
+            dest="s_end_date",
+            default=None,
+            help="The end date (format YYYY-MM-DD) to select - Backtesting",
+        )
+        ns_parser = parse_known_args_and_warn(
+            parser, other_args, export_allowed=EXPORT_ONLY_FIGURES_ALLOWED
+        )
+        if not ns_parser:
+            return
+
+        # BACKTESTING CHECK
+        if ns_parser.s_end_date:
+
+            if ns_parser.s_end_date < self.data.index[0]:
+                print(
+                    "Backtesting not allowed, since End Date is older than Start Date of historical data\n"
+                )
+                return
+
+            if ns_parser.s_end_date < get_next_stock_market_days(
+                last_stock_day=self.data.index[0],
+                n_next_days=5 + ns_parser.n_days,
+            )[-1]:
+                print(
+                    "Backtesting not allowed, since End Date is too close to Start Date to train model\n"
+                )
+                return
+
+        arima_view.display_arima(
+            dataset=self.coin,
+            values=self.data[self.target],
+            arima_order=ns_parser.s_order,
+            n_predict=ns_parser.n_days,
+            seasonal=ns_parser.b_seasonal,
+            ic=ns_parser.s_ic,
+            results=ns_parser.b_results,
+            s_end_date=ns_parser.s_end_date,
+            export=ns_parser.export,
+        )
+
+    @try_except
+    def call_mlp(self, other_args: List[str]):
+        """Process mlp command"""
+        try:
+            ns_parser = pred_helper.parse_args(
+                prog="mlp",
+                description="""Multi-Layered-Perceptron. """,
+                other_args=other_args,
+            )
+            if not ns_parser:
+                return
+
+            neural_networks_view.display_mlp(
+                dataset=self.coin,
+                data=self.data[self.target],
+                n_input_days=ns_parser.n_inputs,
+                n_predict_days=ns_parser.n_days,
+                learning_rate=ns_parser.lr,
+                epochs=ns_parser.n_epochs,
+                batch_size=ns_parser.n_batch_size,
+                test_size=ns_parser.valid_split,
+                n_loops=ns_parser.n_loops,
+                no_shuffle=ns_parser.no_shuffle,
+            )
+        except Exception as e:
+            print(e, "\n")
+
+        finally:
+            pred_helper.restore_env()
+
+    def call_rnn(self, other_args: List[str]):
+        """Process rnn command"""
+        try:
+            ns_parser = pred_helper.parse_args(
+                prog="rnn",
+                description="""Recurrent Neural Network. """,
+                other_args=other_args,
+            )
+            if not ns_parser:
+                return
+
+            neural_networks_view.display_rnn(
+                dataset=self.coin,
+                data=self.data[self.target],
+                n_input_days=ns_parser.n_inputs,
+                n_predict_days=ns_parser.n_days,
+                learning_rate=ns_parser.lr,
+                epochs=ns_parser.n_epochs,
+                batch_size=ns_parser.n_batch_size,
+                test_size=ns_parser.valid_split,
+                n_loops=ns_parser.n_loops,
+                no_shuffle=ns_parser.no_shuffle,
+            )
+
+        except Exception as e:
+            print(e, "\n")
+
+        finally:
+            pred_helper.restore_env()
+
+    def call_lstm(self, other_args: List[str]):
+        """Process lstm command"""
+        try:
+            ns_parser = pred_helper.parse_args(
+                prog="lstm",
+                description="""Long-Short Term Memory. """,
+                other_args=other_args,
+            )
+            if not ns_parser:
+                return
+            neural_networks_view.display_lstm(
+                dataset=self.coin,
+                data=self.data[self.target],
+                n_input_days=ns_parser.n_inputs,
+                n_predict_days=ns_parser.n_days,
+                learning_rate=ns_parser.lr,
+                epochs=ns_parser.n_epochs,
+                batch_size=ns_parser.n_batch_size,
+                test_size=ns_parser.valid_split,
+                n_loops=ns_parser.n_loops,
+                no_shuffle=ns_parser.no_shuffle,
+            )
+
+        except Exception as e:
+            print(e, "\n")
+
+        finally:
+            pred_helper.restore_env()
+
+    def call_conv1d(self, other_args: List[str]):
+        """Process conv1d command"""
+        try:
+            ns_parser = pred_helper.parse_args(
+                prog="conv1d",
+                description="""1D CNN.""",
+                other_args=other_args,
+            )
+            if not ns_parser:
+                return
+
+            neural_networks_view.display_conv1d(
+                dataset=self.coin,
+                data=self.data[self.target],
+                n_input_days=ns_parser.n_inputs,
+                n_predict_days=ns_parser.n_days,
+                learning_rate=ns_parser.lr,
+                epochs=ns_parser.n_epochs,
+                batch_size=ns_parser.n_batch_size,
+                test_size=ns_parser.valid_split,
+                n_loops=ns_parser.n_loops,
+                no_shuffle=ns_parser.no_shuffle,
+            )
+
+        except Exception as e:
+            print(e, "\n")
+
+        finally:
+            pred_helper.restore_env()
+
+    @try_except
+    def call_mc(self, other_args: List[str]):
+        """Process mc command"""
+        parser = argparse.ArgumentParser(
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            add_help=False,
+            prog="mc",
+            description="""
+                Perform Monte Carlo forecasting
+            """,
+        )
+        parser.add_argument(
+            "-d",
+            "--days",
+            help="Days to predict",
+            dest="n_days",
+            type=check_positive,
+            default=30,
+        )
+        parser.add_argument(
+            "-n",
+            "--num",
+            help="Number of simulations to perform",
+            dest="n_sims",
+            default=100,
+        )
+        parser.add_argument(
+            "--dist",
+            choices=["normal", "lognormal"],
+            default="lognormal",
+            dest="dist",
+            help="Whether to model returns or log returns",
+        )
+
+        ns_parser = parse_known_args_and_warn(
+            parser, other_args, export_allowed=EXPORT_ONLY_FIGURES_ALLOWED
+        )
+        if not ns_parser:
+            return
+        if self.target != "Close":
+            print("MC Prediction designed for AdjClose prices")
+            return
+
+        mc_view.display_mc_forecast(
+            data=self.data[self.target],
+            n_future=ns_parser.n_days,
+            n_sims=ns_parser.n_sims,
+            use_log=ns_parser.dist == "lognormal",
+            export=ns_parser.export,
+        )
+
+
+def menu(coin: str, data: pd.DataFrame):
+    """Prediction Techniques Menu"""
+
+    pred_controller = PredictionTechniquesController(coin, data)
+    pred_controller.call_help(None)
+
+    while True:
+        # Get input command from user
+        if session and gtff.USE_PROMPT_TOOLKIT:
+            completer = NestedCompleter.from_nested_dict(
+                {c: None for c in pred_controller.CHOICES}
+            )
+            an_input = session.prompt(
+                f"{get_flair()} (crypto)>(pred)> ",
+                completer=completer,
+            )
+        else:
+            an_input = input(f"{get_flair()} (crypto)>(pred)> ")
+
+        try:
+            plt.close("all")
+
+            process_input = pred_controller.switch(an_input)
+
+            if process_input is not None:
+                return process_input
+
+        except SystemExit:
+            print("The command selected doesn't exist\n")
+            similar_cmd = difflib.get_close_matches(
+                an_input, pred_controller.CHOICES, n=1, cutoff=0.7
+            )
+
+            if similar_cmd:
+                print(f"Did you mean '{similar_cmd[0]}'?\n")
+            continue


### PR DESCRIPTION
Been losing money using the stock prediction?  Well now you can lose even more when the markets are closed or just cuz.

This PR integrates the common prediction functions into crypto stuff.

Some notes:

- The crypto loading is still a bit of a mystery to me, so I am defaulting to loading from CoinGecko when entering the prediction menu.  This is a clear TODO.
- All of the prediction views got a time_res added to them so that timestamps that are less than daily can be plotted.  Another TODO is to integrate these with intraday stock data.  Not in the scope here.
- Kind of roundabout, but to do smaller timestamps, the user can `load` in the prediction menu.  Since I limit to just cg, I didn't think it made sense to add this to load, also since other sources can specify a resolution, but for CG, I am just downloading then resampling into ohlc...

Some screens:
Loading intraday bitcoin data
<img width="391" alt="Screen Shot 2021-11-30 at 2 21 21 PM" src="https://user-images.githubusercontent.com/18151143/144113649-fb61c7a1-25c7-4d51-a1fc-a3f8ce82a822.png">

Predicting the next 24 hours of bitcoin
<img width="925" alt="Screen Shot 2021-11-30 at 2 23 25 PM" src="https://user-images.githubusercontent.com/18151143/144114034-0561f4d6-c66c-4de4-a93f-e39c5ce56a78.png">

