### PR TITLE
Improve comparison analysis controller to not depend on main ticker

### DIFF
--- a/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
@@ -6,18 +6,21 @@ import difflib
 import random
 from typing import List
 
+from datetime import datetime, timedelta
+import yfinance as yf
 from colorama import Style
-import pandas as pd
 from matplotlib import pyplot as plt
 from prompt_toolkit.completion import NestedCompleter
 
 from gamestonk_terminal import feature_flags as gtff
 from gamestonk_terminal.helper_funcs import (
     check_non_negative,
+    check_positive,
     get_flair,
     parse_known_args_and_warn,
     try_except,
     system_clear,
+    valid_date,
 )
 from gamestonk_terminal.menu import session
 from gamestonk_terminal.portfolio.portfolio_optimization import po_controller
@@ -31,7 +34,6 @@ from gamestonk_terminal.stocks.comparison_analysis import (
     yahoo_finance_view,
     yahoo_finance_model,
 )
-from gamestonk_terminal.stocks.stocks_helper import load
 
 # pylint: disable=E1121
 
@@ -43,12 +45,13 @@ class ComparisonAnalysisController:
     CHOICES = ["?", "cls", "help", "q", "quit"]
 
     CHOICES_COMMANDS = [
-        "load",
+        "set",
         "getpoly",
         "getfinnhub",
         "getfinviz",
         "select",
         "add",
+        "rmv",
         "historical",
         "hcorr",
         "volume",
@@ -70,36 +73,25 @@ class ComparisonAnalysisController:
 
     def __init__(
         self,
-        ticker: str,
-        start: str,
-        interval: str,
-        stock: pd.DataFrame,
-        similar: List = None,
+        similar: List[str] = None,
     ):
         """Constructor
 
         Parameters
         ----------
-        ticker : str
-            Stock ticker
-        start : str
-            Start time
-        interval : str
-            Time interval
-        stock : pd.DataFrame
-            Stock data
         similar : List
             Similar tickers
         """
-        self.ticker = ticker
-        self.start = start
-        self.interval = interval
-        self.stock = stock
-
         if similar:
             self.similar = similar
         else:
-            self.similar = list()
+            self.similar = []
+
+        if similar and len(similar) == 1:
+            self.ticker = self.similar[0].upper()
+        else:
+            self.ticker = ""
+
         self.user = ""
 
         self.ca_parser = argparse.ArgumentParser(add_help=False, prog="ca")
@@ -110,41 +102,37 @@ class ComparisonAnalysisController:
 
     def print_help(self):
         """Print help"""
-        all_loaded = bool(not self.ticker or not self.similar)
-        if self.start:
-            stock_str = f"Stock: {self.ticker} (from {self.start.strftime('%Y-%m-%d')})"
-        else:
-            stock_str = f"Stock: {self.ticker}"
         help_str = f"""
 Comparison Analysis:
     cls           clear screen
     ?/help        show this menu again
     q             quit this menu, and shows back to main menu
     quit          quit to abandon program
+    set           set ticker to get similars from
 
-    load          load new base ticker
-    add           add more companies to current selected (max 10 total)
-    select        reset and select similar companies
-
-{stock_str}
-Similar Companies: {', '.join(self.similar) or None}
-
-Get Similar:
-    tsne          run TSNE on all SP500 stocks and returns 10 closest tickers
+Get similar: {self.ticker}{Style.NORMAL if self.ticker else Style.DIM}
+    tsne          run TSNE on all SP500 stocks and returns closest tickers
     getpoly       get similar stocks from polygon API
     getfinnhub    get similar stocks from finnhub API
-    getfinviz     get similar stocks from finviz API
-{Style.DIM if all_loaded else Style.NORMAL}Yahoo Finance:
+    getfinviz     get similar stocks from finviz API{Style.RESET_ALL}
+
+    select        reset and select similar companies
+    add           add more companies to current selected
+    rmv           remove companies to currently selected
+
+Similar Companies: {', '.join(self.similar) if self.similar else ''}
+{Style.NORMAL if self.similar else Style.DIM}
+Yahoo Finance:
     historical    historical price data comparison
     hcorr         historical price correlation
-    volume        historical volume data comparison {Style.RESET_ALL}
+    volume        historical volume data comparison
 Market Watch:
     income        income financials comparison
     balance       balance financials comparison
     cashflow      cashflow comparison
 Finbrain:
-    sentiment     sentiment analysis comparison {Style.DIM if all_loaded else Style.NORMAL}
-    scorr         sentiment correlation{Style.RESET_ALL}
+    sentiment     sentiment analysis comparison
+    scorr         sentiment correlation
 Finviz:
     overview      brief overview comparison
     valuation     brief valuation comparison
@@ -153,17 +141,48 @@ Finviz:
     performance   brief performance comparison
     technical     brief technical comparison
 
->   po            portfolio optimization for selected tickers
+>   po            portfolio optimization for selected tickers{Style.RESET_ALL}
         """
         print(help_str)
 
-    def call_load(self, other_args: List[str]):
-        """Process load command"""
-        self.ticker, self.start, self.interval, self.stock = load(
-            other_args, self.ticker, self.start, self.interval, self.stock
+    @try_except
+    def call_set(self, other_args: List[str]):
+        """Process set command"""
+        parser = argparse.ArgumentParser(
+            add_help=False,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            prog="set",
+            description="""Set ticker to extract similars from""",
         )
-        if "." in self.ticker:
-            self.ticker = self.ticker.split(".")[0]
+        parser.add_argument(
+            "-t",
+            "--ticker",
+            dest="ticker",
+            type=str,
+            required=True,
+            help="Ticker get similar tickers from",
+        )
+
+        # For the case where a user uses: 'add NIO,XPEV,LI'
+        if other_args and "-" not in other_args[0]:
+            other_args.insert(0, "-t")
+
+        ns_parser = parse_known_args_and_warn(parser, other_args)
+        if not ns_parser:
+            return
+
+        if "," in ns_parser.ticker:
+            print("Only one ticker must be selected!")
+        else:
+            stock_data = yf.download(
+                ns_parser.ticker,
+                progress=False,
+            )
+            if stock_data.empty:
+                print(f"The ticker '{ns_parser.ticker}' provided does not exist!")
+            else:
+                self.ticker = ns_parser.ticker.upper()
+        print("")
 
     @try_except
     def call_tsne(self, other_args: List[str]):
@@ -175,12 +194,20 @@ Finviz:
             description="""Get similar companies to compare with using sklearn TSNE.""",
         )
         parser.add_argument(
-            "-l",
+            "-r",
             "--learnrate",
             default=200,
             dest="lr",
             type=check_non_negative,
             help="TSNE Learning rate.  Typical values are between 50 and 200",
+        )
+        parser.add_argument(
+            "-l",
+            "--limit",
+            default=10,
+            dest="limit",
+            type=check_positive,
+            help="Limit of stocks to retrieve. The subsample will occur randomly.",
         )
         parser.add_argument(
             "-p", "--no_plot", action="store_true", default=False, dest="no_plot"
@@ -190,8 +217,14 @@ Finviz:
         if not ns_parser:
             return
         self.similar = yahoo_finance_model.get_sp500_comps_tsne(
-            self.ticker, lr=ns_parser.lr, no_plot=ns_parser.no_plot
+            self.ticker,
+            lr=ns_parser.lr,
+            no_plot=ns_parser.no_plot,
+            num_tickers=ns_parser.limit,
         )
+
+        self.similar = [self.ticker] + self.similar
+
         print(f"[ML] Similar Companies: {', '.join(self.similar)}", "\n")
 
     @try_except
@@ -233,6 +266,8 @@ Finviz:
             )
 
         if self.similar:
+            self.similar = [self.ticker] + self.similar
+
             print(f"[{self.user}] Similar Companies: {', '.join(self.similar)}", "\n")
 
     @try_except
@@ -270,6 +305,8 @@ Finviz:
                 "The limit of stocks to compare with are 10. Hence, 10 random similar stocks will be displayed.\n",
             )
 
+        self.similar = [self.ticker] + self.similar
+
         if self.similar:
             print(f"[{self.user}] Similar Companies: {', '.join(self.similar)}", "\n")
 
@@ -298,6 +335,8 @@ Finviz:
                 "The limit of stocks to compare with are 10. Hence, 10 random similar stocks will be displayed.\n",
             )
 
+        self.similar = [self.ticker] + self.similar
+
         if self.similar:
             print(f"[{self.user}] Similar Companies: {', '.join(self.similar)}", "\n")
 
@@ -308,7 +347,7 @@ Finviz:
             add_help=False,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
             prog="add",
-            description="""Add similar companies to compare with.""",
+            description="""Add similar tickers to compare with.""",
         )
         parser.add_argument(
             "-s",
@@ -316,7 +355,7 @@ Finviz:
             dest="l_similar",
             type=lambda s: [str(item).upper() for item in s.split(",")],
             default=[],
-            help="similar companies to compare with.",
+            help="Tickers to add to similar list",
         )
 
         # For the case where a user uses: 'add NIO,XPEV,LI'
@@ -327,9 +366,44 @@ Finviz:
         if not ns_parser:
             return
         # Add sets to avoid duplicates
-        self.similar = list(set(self.similar + ns_parser.l_similar))
-        if len(self.similar) > 10:
-            self.similar = list(random.sample(set(self.similar), 10))
+        if self.similar:
+            self.similar = list(set(self.similar + ns_parser.l_similar))
+        else:
+            self.similar = ns_parser.l_similar
+        self.user = "Custom"
+        print(f"[{self.user}] Similar Companies: {', '.join(self.similar)}", "\n")
+
+    @try_except
+    def call_rmv(self, other_args: List[str]):
+        """Process rmv command"""
+        parser = argparse.ArgumentParser(
+            add_help=False,
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+            prog="rmv",
+            description="""Remove similar tickers to compare with.""",
+        )
+        parser.add_argument(
+            "-s",
+            "--similar",
+            dest="l_similar",
+            type=lambda s: [str(item).upper() for item in s.split(",")],
+            default=[],
+            help="Tickers to remove from similar list",
+        )
+
+        # For the case where a user uses: 'add NIO,XPEV,LI'
+        if other_args and "-" not in other_args[0]:
+            other_args.insert(0, "-s")
+
+        ns_parser = parse_known_args_and_warn(parser, other_args)
+        if not ns_parser:
+            return
+        # Add sets to avoid duplicates
+        for symbol in ns_parser.l_similar:
+            if symbol in self.similar:
+                self.similar.remove(symbol)
+            else:
+                print(f"Ticker {symbol} does not exist in similar list to be removed")
         self.user = "Custom"
         print(f"[{self.user}] Similar Companies: {', '.join(self.similar)}", "\n")
 
@@ -432,8 +506,16 @@ Finviz:
             "--no-scale",
             action="store_false",
             dest="no_scale",
-            default=True,
+            default=False,
             help="Flag to not put all prices on same 0-1 scale",
+        )
+        parser.add_argument(
+            "-s",
+            "--start",
+            type=valid_date,
+            default=(datetime.now() - timedelta(days=366)).strftime("%Y-%m-%d"),
+            dest="start",
+            help="The starting date (format YYYY-MM-DD) of the stock",
         )
         parser.add_argument(
             "--export",
@@ -443,29 +525,21 @@ Finviz:
             dest="export",
             help="Export dataframe data to csv,json,xlsx file",
         )
+        ns_parser = parse_known_args_and_warn(parser, other_args)
+        if not ns_parser:
+            return
 
-        if self.interval != "1440min":
-            print("Intraday historical data analysis comparison is not yet available.")
-            # Alpha Vantage only supports 5 calls per minute, we need another API to get intraday data
-        else:
-            ns_parser = parse_known_args_and_warn(parser, other_args)
-            if not ns_parser:
-                return
+        if not self.similar:
+            print("Please make sure there are similar tickers selected. \n")
+            return
 
-            if not self.similar or not self.ticker:
-                print(
-                    "Please make sure there are both a loaded ticker and similar tickers selected. \n"
-                )
-                return
-
-            yahoo_finance_view.display_historical(
-                ticker=self.ticker,
-                similar_tickers=self.similar,
-                start=self.start,
-                candle_type=ns_parser.type_candle,
-                normalize=ns_parser.no_scale,
-                export=ns_parser.export,
-            )
+        yahoo_finance_view.display_historical(
+            similar_tickers=self.similar,
+            start=ns_parser.start,
+            candle_type=ns_parser.type_candle,
+            normalize=not ns_parser.no_scale,
+            export=ns_parser.export,
+        )
 
     @try_except
     def call_hcorr(self, other_args: List[str]):
@@ -488,21 +562,26 @@ Finviz:
             default="a",  # in case it's adjusted close
             help="Candle data to use: o-open, h-high, l-low, c-close, a-adjusted close.",
         )
+        parser.add_argument(
+            "-s",
+            "--start",
+            type=valid_date,
+            default=(datetime.now() - timedelta(days=366)).strftime("%Y-%m-%d"),
+            dest="start",
+            help="The starting date (format YYYY-MM-DD) of the stock",
+        )
 
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if not ns_parser:
             return
 
-        if not self.similar or not self.ticker:
-            print(
-                "Please make sure there are both a loaded ticker and similar tickers selected. \n"
-            )
+        if not self.similar:
+            print("Please make sure there are similar tickers selected. \n")
             return
 
         yahoo_finance_view.display_correlation(
-            ticker=self.ticker,
             similar_tickers=self.similar,
-            start=self.start,
+            start=ns_parser.start,
             candle_type=ns_parser.type_candle,
         )
 
@@ -548,7 +627,6 @@ Finviz:
             return
 
         marketwatch_view.display_income_comparison(
-            ticker=self.ticker,
             similar=self.similar,
             timeframe=ns_parser.s_timeframe,
             quarter=ns_parser.b_quarter,
@@ -566,11 +644,11 @@ Finviz:
         )
         parser.add_argument(
             "-s",
-            "--scale",
-            action="store_true",
-            dest="scale",
-            default=False,
-            help="Flag to not put all prices on same 0-1 scale",
+            "--start",
+            type=valid_date,
+            default=(datetime.now() - timedelta(days=366)).strftime("%Y-%m-%d"),
+            dest="start",
+            help="The starting date (format YYYY-MM-DD) of the stock",
         )
         parser.add_argument(
             "--export",
@@ -580,28 +658,19 @@ Finviz:
             dest="export",
             help="Export dataframe data to csv,json,xlsx file",
         )
+        ns_parser = parse_known_args_and_warn(parser, other_args)
+        if not ns_parser:
+            return
 
-        if self.interval != "1440min":
-            print("Intraday historical data analysis comparison is not yet available.")
-            # Alpha Vantage only supports 5 calls per minute, we need another API to get intraday data
-        else:
-            ns_parser = parse_known_args_and_warn(parser, other_args)
-            if not ns_parser:
-                return
+        if not self.similar:
+            print("Please make sure there are similar tickers selected. \n")
+            return
 
-            if not self.similar or not self.ticker:
-                print(
-                    "Please make sure there are both a loaded ticker and similar tickers selected. \n"
-                )
-                return
-
-            yahoo_finance_view.display_volume(
-                ticker=self.ticker,
-                similar_tickers=self.similar,
-                start=self.start,
-                normalize=ns_parser.scale,
-                export=ns_parser.export,
-            )
+        yahoo_finance_view.display_volume(
+            similar_tickers=self.similar,
+            start=ns_parser.start,
+            export=ns_parser.export,
+        )
 
     @try_except
     def call_balance(self, other_args: List[str]):
@@ -645,7 +714,6 @@ Finviz:
             return
 
         marketwatch_view.display_balance_comparison(
-            ticker=self.ticker,
             similar=self.similar,
             timeframe=ns_parser.s_timeframe,
             quarter=ns_parser.b_quarter,
@@ -693,7 +761,6 @@ Finviz:
             return
 
         marketwatch_view.display_cashflow_comparison(
-            ticker=self.ticker,
             similar=self.similar,
             timeframe=ns_parser.s_timeframe,
             quarter=ns_parser.b_quarter,
@@ -731,7 +798,6 @@ Finviz:
             return
 
         finbrain_view.display_sentiment_compare(
-            ticker=self.ticker,
             similar=self.similar,
             raw=ns_parser.raw,
             export=ns_parser.export,
@@ -768,13 +834,10 @@ Finviz:
         if not ns_parser:
             return
 
-        if not self.similar or not self.ticker:
-            print(
-                "Please make sure there are both a loaded ticker and similar tickers selected. \n"
-            )
+        if not self.similar:
+            print("Please make sure there are similar tickers selected. \n")
             return
         finbrain_view.display_sentiment_correlation(
-            ticker=self.ticker,
             similar=self.similar,
             raw=ns_parser.raw,
             export=ns_parser.export,
@@ -804,7 +867,6 @@ Finviz:
             return
 
         finviz_compare_view.screener(
-            ticker=self.ticker,
             similar=self.similar,
             data_type="overview",
             export=ns_parser.export,
@@ -834,7 +896,6 @@ Finviz:
             return
 
         finviz_compare_view.screener(
-            ticker=self.ticker,
             similar=self.similar,
             data_type="valuation",
             export=ns_parser.export,
@@ -864,7 +925,6 @@ Finviz:
             return
 
         finviz_compare_view.screener(
-            ticker=self.ticker,
             similar=self.similar,
             data_type="financial",
             export=ns_parser.export,
@@ -894,7 +954,6 @@ Finviz:
             return
 
         finviz_compare_view.screener(
-            ticker=self.ticker,
             similar=self.similar,
             data_type="ownership",
             export=ns_parser.export,
@@ -924,7 +983,6 @@ Finviz:
             return
 
         finviz_compare_view.screener(
-            ticker=self.ticker,
             similar=self.similar,
             data_type="performance",
             export=ns_parser.export,
@@ -954,7 +1012,6 @@ Finviz:
             return
 
         finviz_compare_view.screener(
-            ticker=self.ticker,
             similar=self.similar,
             data_type="technical",
             export=ns_parser.export,
@@ -962,29 +1019,19 @@ Finviz:
 
     def call_po(self, _):
         """Call the portfolio optimization menu with selected tickers"""
-        return po_controller.menu([self.ticker] + self.similar)
+        return po_controller.menu(self.similar)
 
 
-def menu(ticker: str, start: str, interval: str, stock: pd.DataFrame, similar: List):
+def menu(similar: List):
     """Comparison Analysis Menu
 
     Parameters
     ----------
-    ticker : str
-        Stock ticker
-    start : str
-        Time start
-    interval : str
-        Time interval
-    stock : pd.DataFrame
-        Stock data
     similar : List
         Similar tickers
     """
 
-    ca_controller = ComparisonAnalysisController(
-        ticker, start, interval, stock, similar
-    )
+    ca_controller = ComparisonAnalysisController(similar)
     ca_controller.call_help(None)
 
     while True:

--- a/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
@@ -216,6 +216,11 @@ Finviz:
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if not ns_parser:
             return
+
+        if not self.ticker:
+            print("You need to 'set' a ticker to get similar companies from first!")
+            return
+
         self.similar = yahoo_finance_model.get_sp500_comps_tsne(
             self.ticker,
             lr=ns_parser.lr,
@@ -246,6 +251,11 @@ Finviz:
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if not ns_parser:
             return
+
+        if not self.ticker:
+            print("You need to 'set' a ticker to get similar companies from first!")
+            return
+
         if ns_parser.b_no_country:
             compare_list = ["Sector", "Industry"]
         else:
@@ -291,6 +301,11 @@ Finviz:
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if not ns_parser:
             return
+
+        if not self.ticker:
+            print("You need to 'set' a ticker to get similar companies from first!")
+            return
+
         self.similar, self.user = polygon_model.get_similar_companies(
             self.ticker, ns_parser.us_only
         )
@@ -321,6 +336,10 @@ Finviz:
         )
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if not ns_parser:
+            return
+
+        if not self.ticker:
+            print("You need to 'set' a ticker to get similar companies from first!")
             return
 
         self.similar, self.user = finnhub_model.get_similar_companies(self.ticker)

--- a/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
@@ -529,8 +529,8 @@ Finviz:
         if not ns_parser:
             return
 
-        if not self.similar:
-            print("Please make sure there are similar tickers selected. \n")
+        if not self.similar or len(self.similar) == 1:
+            print("Please make sure there are more than 1 similar tickers selected. \n")
             return
 
         yahoo_finance_view.display_historical(
@@ -575,7 +575,7 @@ Finviz:
         if not ns_parser:
             return
 
-        if not self.similar:
+        if not self.similar or len(self.similar) == 1:
             print("Please make sure there are similar tickers selected. \n")
             return
 
@@ -662,7 +662,7 @@ Finviz:
         if not ns_parser:
             return
 
-        if not self.similar:
+        if not self.similar or len(self.similar) == 1:
             print("Please make sure there are similar tickers selected. \n")
             return
 
@@ -834,9 +834,10 @@ Finviz:
         if not ns_parser:
             return
 
-        if not self.similar:
+        if not self.similar or len(self.similar) == 1:
             print("Please make sure there are similar tickers selected. \n")
             return
+
         finbrain_view.display_sentiment_correlation(
             similar=self.similar,
             raw=ns_parser.raw,

--- a/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
@@ -108,17 +108,19 @@ Comparison Analysis:
     ?/help        show this menu again
     q             quit this menu, and shows back to main menu
     quit          quit to abandon program
-    set           set ticker to get similars from
 
-Get similar: {self.ticker}{Style.NORMAL if self.ticker else Style.DIM}
+    set           set ticker to get similar companies from
+
+Ticker to get similar companies from: {self.ticker}{Style.NORMAL if self.ticker else Style.DIM}
+
     tsne          run TSNE on all SP500 stocks and returns closest tickers
     getpoly       get similar stocks from polygon API
     getfinnhub    get similar stocks from finnhub API
     getfinviz     get similar stocks from finviz API{Style.RESET_ALL}
 
     select        reset and select similar companies
-    add           add more companies to current selected
-    rmv           remove companies to currently selected
+    add           add more similar companies
+    rmv           remove similar companies individually or all
 
 Similar Companies: {', '.join(self.similar) if self.similar else ''}
 {Style.NORMAL if self.similar else Style.DIM}
@@ -417,14 +419,24 @@ Finviz:
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if not ns_parser:
             return
-        # Add sets to avoid duplicates
-        for symbol in ns_parser.l_similar:
-            if symbol in self.similar:
-                self.similar.remove(symbol)
-            else:
-                print(f"Ticker {symbol} does not exist in similar list to be removed")
+
+        if ns_parser.l_similar:
+            # Add sets to avoid duplicates
+            for symbol in ns_parser.l_similar:
+                if symbol in self.similar:
+                    self.similar.remove(symbol)
+                else:
+                    print(
+                        f"Ticker {symbol} does not exist in similar list to be removed"
+                    )
+
+            print(f"[{self.user}] Similar Companies: {', '.join(self.similar)}")
+
+        else:
+            self.similar = []
+
+        print("")
         self.user = "Custom"
-        print(f"[{self.user}] Similar Companies: {', '.join(self.similar)}", "\n")
 
     @try_except
     def call_select(self, other_args: List[str]):

--- a/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
@@ -45,11 +45,11 @@ class ComparisonAnalysisController:
     CHOICES = ["?", "cls", "help", "q", "quit"]
 
     CHOICES_COMMANDS = [
-        "set",
+        "ticker",
         "getpoly",
         "getfinnhub",
         "getfinviz",
-        "select",
+        "set",
         "add",
         "rmv",
         "historical",
@@ -109,21 +109,20 @@ Comparison Analysis:
     q             quit this menu, and shows back to main menu
     quit          quit to abandon program
 
-    set           set ticker to get similar companies from
+    ticker        set ticker to get similar companies from{Style.NORMAL if self.ticker else Style.DIM}
 
-Ticker to get similar companies from: {self.ticker}{Style.NORMAL if self.ticker else Style.DIM}
-
+Ticker to get similar companies from: {self.ticker}
     tsne          run TSNE on all SP500 stocks and returns closest tickers
     getpoly       get similar stocks from polygon API
     getfinnhub    get similar stocks from finnhub API
     getfinviz     get similar stocks from finviz API{Style.RESET_ALL}
 
-    select        reset and select similar companies
+    set           reset and set similar companies
     add           add more similar companies
     rmv           remove similar companies individually or all
-
+{Style.NORMAL if self.similar and len(self.similar)>1 else Style.DIM}
 Similar Companies: {', '.join(self.similar) if self.similar else ''}
-{Style.NORMAL if self.similar else Style.DIM}
+
 Yahoo Finance:
     historical    historical price data comparison
     hcorr         historical price correlation
@@ -148,12 +147,12 @@ Finviz:
         print(help_str)
 
     @try_except
-    def call_set(self, other_args: List[str]):
-        """Process set command"""
+    def call_ticker(self, other_args: List[str]):
+        """Process ticker command"""
         parser = argparse.ArgumentParser(
             add_help=False,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-            prog="set",
+            prog="ticker",
             description="""Set ticker to extract similars from""",
         )
         parser.add_argument(
@@ -439,12 +438,12 @@ Finviz:
         self.user = "Custom"
 
     @try_except
-    def call_select(self, other_args: List[str]):
-        """Process select command"""
+    def call_set(self, other_args: List[str]):
+        """Process set command"""
         parser = argparse.ArgumentParser(
             add_help=False,
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
-            prog="select",
+            prog="set",
             description="""Select similar companies to compare with.""",
         )
         parser.add_argument(
@@ -828,6 +827,10 @@ Finviz:
         if not ns_parser:
             return
 
+        if not self.similar or len(self.similar) == 1:
+            print("Please make sure there are more than 1 similar tickers selected. \n")
+            return
+
         finbrain_view.display_sentiment_compare(
             similar=self.similar,
             raw=ns_parser.raw,
@@ -898,6 +901,10 @@ Finviz:
         if not ns_parser:
             return
 
+        if not self.similar or len(self.similar) == 1:
+            print("Please make sure there are more than 1 similar tickers selected. \n")
+            return
+
         finviz_compare_view.screener(
             similar=self.similar,
             data_type="overview",
@@ -925,6 +932,10 @@ Finviz:
         )
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if not ns_parser:
+            return
+
+        if not self.similar or len(self.similar) == 1:
+            print("Please make sure there are more than 1 similar tickers selected. \n")
             return
 
         finviz_compare_view.screener(
@@ -956,6 +967,10 @@ Finviz:
         if not ns_parser:
             return
 
+        if not self.similar or len(self.similar) == 1:
+            print("Please make sure there are more than 1 similar tickers selected. \n")
+            return
+
         finviz_compare_view.screener(
             similar=self.similar,
             data_type="financial",
@@ -983,6 +998,10 @@ Finviz:
         )
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if not ns_parser:
+            return
+
+        if not self.similar or len(self.similar) == 1:
+            print("Please make sure there are more than 1 similar tickers selected. \n")
             return
 
         finviz_compare_view.screener(
@@ -1014,6 +1033,10 @@ Finviz:
         if not ns_parser:
             return
 
+        if not self.similar or len(self.similar) == 1:
+            print("Please make sure there are more than 1 similar tickers selected. \n")
+            return
+
         finviz_compare_view.screener(
             similar=self.similar,
             data_type="performance",
@@ -1043,6 +1066,10 @@ Finviz:
         if not ns_parser:
             return
 
+        if not self.similar or len(self.similar) == 1:
+            print("Please make sure there are more than 1 similar tickers selected. \n")
+            return
+
         finviz_compare_view.screener(
             similar=self.similar,
             data_type="technical",
@@ -1051,6 +1078,10 @@ Finviz:
 
     def call_po(self, _):
         """Call the portfolio optimization menu with selected tickers"""
+        if not self.similar or len(self.similar) == 1:
+            print("Please make sure there are more than 1 similar tickers selected. \n")
+            return None
+
         return po_controller.menu(self.similar)
 
 

--- a/gamestonk_terminal/stocks/comparison_analysis/finbrain_model.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/finbrain_model.py
@@ -22,10 +22,11 @@ def get_sentiments(tickers: List[str]) -> pd.DataFrame:
 
     df_sentiment = pd.DataFrame()
     dates_sentiment = []
+    tickers_to_remove = list()
     for ticker in tickers:
         result = requests.get(f"https://api.finbrain.tech/v0/sentiments/{ticker}")
         if result.status_code == 200:
-            if "sentimentAnalysis" in result.json():
+            if "ticker" in result.json() and "sentimentAnalysis" in result.json():
                 df_sentiment[ticker] = [
                     float(val)
                     for val in list(result.json()["sentimentAnalysis"].values())
@@ -33,11 +34,14 @@ def get_sentiments(tickers: List[str]) -> pd.DataFrame:
                 dates_sentiment = list(result.json()["sentimentAnalysis"].keys())
             else:
                 print(f"Unexpected data format from FinBrain API for {ticker}")
-                tickers.remove(ticker)
+                tickers_to_remove.append(ticker)
 
         else:
             print(f"Request error in retrieving {ticker} sentiment from FinBrain API")
-            tickers.remove(ticker)
+            tickers_to_remove.append(ticker)
+
+    for ticker in tickers_to_remove:
+        tickers.remove(ticker)
 
     if not df_sentiment.empty:
         df_sentiment.index = dates_sentiment

--- a/gamestonk_terminal/stocks/comparison_analysis/finbrain_view.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/finbrain_view.py
@@ -21,15 +21,11 @@ from gamestonk_terminal.stocks.comparison_analysis import finbrain_model
 register_matplotlib_converters()
 
 
-def display_sentiment_compare(
-    ticker: str, similar: List[str], raw: bool = False, export: str = ""
-):
-    """Display sentiment for all ticker
+def display_sentiment_compare(similar: List[str], raw: bool = False, export: str = ""):
+    """Display sentiment for all ticker. [Source: FinBrain]
 
     Parameters
     ----------
-    ticker : str
-        Base ticker for comparison
     similar : List[str]
         Similar companies to compare income with
     raw : bool, optional
@@ -37,15 +33,14 @@ def display_sentiment_compare(
     export : str, optional
         Format to export data
     """
-    all_tickers = [ticker, *similar]
-    df_sentiment = finbrain_model.get_sentiments(all_tickers)
+    df_sentiment = finbrain_model.get_sentiments(similar)
     if df_sentiment.empty:
         print("No sentiments found.")
 
     else:
         fig, ax = plt.subplots(figsize=plot_autoscale(), dpi=PLOT_DPI)
 
-        for idx, tick in enumerate(all_tickers):
+        for idx, tick in enumerate(similar):
             offset = 2 * idx
             ax.axhline(y=offset, color="k", linestyle="--", lw=2)
             ax.axhline(y=offset + 1, color="k", linestyle="--", lw=1)
@@ -78,8 +73,8 @@ def display_sentiment_compare(
         ax.grid(b=True, which="major", color="#666666", linestyle="-")
         ax.minorticks_on()
         ax.grid(b=True, which="minor", color="#999999", linestyle="-", alpha=0.2)
-        ax.set_yticks(np.arange(len(all_tickers)) * 2)
-        ax.set_yticklabels(all_tickers)
+        ax.set_yticks(np.arange(len(similar)) * 2)
+        ax.set_yticklabels(similar)
         ax.set_title(f"FinBrain's Sentiment Analysis since {df_sentiment.index[0]}")
         plt.gca().xaxis.set_major_locator(mdates.DayLocator(interval=1))
         plt.gcf().autofmt_xdate()
@@ -110,14 +105,12 @@ def display_sentiment_compare(
 
 
 def display_sentiment_correlation(
-    ticker: str, similar: List[str], raw: bool = False, export: str = ""
+    similar: List[str], raw: bool = False, export: str = ""
 ):
-    """Plot correlation sentiments heatmap across similar companies
+    """Plot correlation sentiments heatmap across similar companies. [Source: FinBrain]
 
     Parameters
     ----------
-    ticker : str
-        Main ticker to compare income
     similar : List[str]
         Similar companies to compare income with
     raw : bool, optional
@@ -125,8 +118,7 @@ def display_sentiment_correlation(
     export : str, optional
         Format to export data
     """
-    all_tickers = [ticker, *similar]
-    df_sentiment = finbrain_model.get_sentiments(all_tickers)
+    df_sentiment = finbrain_model.get_sentiments(similar)
     corrs = df_sentiment.corr()
     if df_sentiment.empty:
         print("No sentiments found.")
@@ -134,7 +126,7 @@ def display_sentiment_correlation(
     else:
         fig, ax = plt.subplots(figsize=plot_autoscale(), dpi=PLOT_DPI)
 
-        mask = np.zeros((len(all_tickers), len(all_tickers)), dtype=bool)
+        mask = np.zeros((len(similar), len(similar)), dtype=bool)
         mask[np.triu_indices(len(mask))] = True
 
         sns.heatmap(

--- a/gamestonk_terminal/stocks/comparison_analysis/finviz_compare_view.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/finviz_compare_view.py
@@ -11,13 +11,11 @@ from gamestonk_terminal.stocks.comparison_analysis import finviz_compare_model
 from gamestonk_terminal import feature_flags as gtff
 
 
-def screener(data_type: str, ticker: str, similar: List[str], export: str = ""):
+def screener(similar: List[str], data_type: str, export: str = ""):
     """Screener
 
     Parameters
     ----------
-    ticker : str
-        Main ticker to compare income
     similar : List[str]
         Similar companies to compare income with
     data_type : str
@@ -25,8 +23,7 @@ def screener(data_type: str, ticker: str, similar: List[str], export: str = ""):
     export : str
         Format to export data
     """
-    all_tickers = [ticker, *similar]
-    df_screen = finviz_compare_model.get_comparison_data(data_type, all_tickers)
+    df_screen = finviz_compare_model.get_comparison_data(data_type, similar)
 
     if df_screen.empty:
         print("No screened data found.")

--- a/gamestonk_terminal/stocks/comparison_analysis/marketwatch_view.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/marketwatch_view.py
@@ -16,18 +16,15 @@ from gamestonk_terminal.stocks.comparison_analysis import marketwatch_model
 
 
 def display_income_comparison(
-    ticker: str,
     similar: List[str],
     timeframe: str,
     quarter: bool = False,
     export: str = "",
 ):
-    """Display income data from Marketwatch
+    """Display income data. [Source: Marketwatch]
 
     Parameters
     ----------
-    ticker : str
-        Base ticker
     similar : List[str]
         List of tickers to compare
     timeframe : str
@@ -37,9 +34,8 @@ def display_income_comparison(
     export : str, optional
         Format to export data
     """
-    all_stocks = [ticker, *similar]
     df_financials_compared = marketwatch_model.get_financial_comparisons(
-        all_stocks, "income", timeframe, quarter
+        similar, "income", timeframe, quarter
     )
     # Export data before the color
     export_data(
@@ -73,18 +69,15 @@ def display_income_comparison(
 
 
 def display_balance_comparison(
-    ticker: str,
     similar: List[str],
     timeframe: str,
     quarter: bool = False,
     export: str = "",
 ):
-    """Compare balance between companies
+    """Compare balance between companies. [Source: Marketwatch]
 
     Parameters
     ----------
-    ticker : str
-        Main ticker to compare income
     similar : List[str]
         Similar companies to compare income with
     timeframe : str
@@ -94,9 +87,8 @@ def display_balance_comparison(
     export : str, optional
         Format to export data
     """
-    all_stocks = [ticker, *similar]
     df_financials_compared = marketwatch_model.get_financial_comparisons(
-        all_stocks, "balance", timeframe, quarter
+        similar, "balance", timeframe, quarter
     )
     # Export data before the color
     export_data(
@@ -130,13 +122,12 @@ def display_balance_comparison(
 
 
 def display_cashflow_comparison(
-    ticker: str,
     similar: List[str],
     timeframe: str,
     quarter: bool = False,
     export: str = "",
 ):
-    """Compare cashflow between companies
+    """Compare cashflow between companies. [Source: Marketwatch]
 
     Parameters
     ----------
@@ -151,9 +142,8 @@ def display_cashflow_comparison(
     export : str, optional
         Format to export data
     """
-    all_stocks = [ticker, *similar]
     df_financials_compared = marketwatch_model.get_financial_comparisons(
-        all_stocks, "cashflow", timeframe, quarter
+        similar, "cashflow", timeframe, quarter
     )
 
     # Export data before the color

--- a/gamestonk_terminal/stocks/comparison_analysis/yahoo_finance_model.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/yahoo_finance_model.py
@@ -24,7 +24,6 @@ d_candle_types = {
 
 
 def get_historical(
-    ticker: str,
     similar_tickers: List[str],
     start: str = (datetime.now() - timedelta(days=366)).strftime("%Y-%m-%d"),
     candle_type: str = "a",
@@ -33,8 +32,6 @@ def get_historical(
 
     Parameters
     ----------
-    ticker : str
-        Base ticker
     similar_tickers : List[str]
         List of similar tickers
     start : str, optional
@@ -47,12 +44,11 @@ def get_historical(
     pd.DataFrame
         Dataframe containing candle type variable for each ticker
     """
-    all_tickers = [ticker, *similar_tickers]
     # To avoid having to recursively append, just do a single yfinance call.  This will give dataframe
     # where all tickers are columns.
-    return yf.download(all_tickers, start=start, progress=False, threads=False)[
+    return yf.download(similar_tickers, start=start, progress=False, threads=False)[
         d_candle_types[candle_type]
-    ][all_tickers]
+    ][similar_tickers]
 
 
 def get_1y_sp500() -> pd.DataFrame:

--- a/gamestonk_terminal/stocks/comparison_analysis/yahoo_finance_view.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/yahoo_finance_view.py
@@ -30,7 +30,6 @@ d_candle_types = {
 
 
 def display_historical(
-    ticker: str,
     similar_tickers: List[str],
     start: str = (datetime.now() - timedelta(days=366)).strftime("%Y-%m-%d"),
     candle_type: str = "a",
@@ -41,8 +40,6 @@ def display_historical(
 
     Parameters
     ----------
-    ticker : str
-        Base ticker
     similar_tickers : List[str]
         List of similar tickers
     start : str, optional
@@ -54,12 +51,9 @@ def display_historical(
     export : str, optional
         Format to export historical prices, by default ""
     """
-    ordered_tickers = [ticker, *similar_tickers]
-    df_similar = yahoo_finance_model.get_historical(
-        ticker, similar_tickers, start, candle_type
-    )
-    # To plot with ticker first
-    df_similar = df_similar[ordered_tickers]
+    df_similar = yahoo_finance_model.get_historical(similar_tickers, start, candle_type)
+    df_similar = df_similar[similar_tickers]
+
     if np.any(df_similar.isna()):
         nan_tickers = df_similar.columns[df_similar.isna().sum() >= 1].to_list()
         print(f"NaN values found in: {', '.join(nan_tickers)}.  Replacing with zeros.")
@@ -74,7 +68,7 @@ def display_historical(
             index=df_similar.index,
         )
     df_similar.plot(ax=ax)
-    ax.set_title(f"Similar companies to {ticker}")
+    ax.set_title(f"Historical price of {', '.join(similar_tickers)}")
     ax.set_xlabel("Time")
     ax.set_ylabel(f"{['','Normalized'][normalize]} Share Price {['($)',''][normalize]}")
     ax.grid(b=True, which="major", color="#666666", linestyle="-")
@@ -90,18 +84,14 @@ def display_historical(
 
 
 def display_volume(
-    ticker: str,
     similar_tickers: List[str],
     start: str = (datetime.now() - timedelta(days=366)).strftime("%Y-%m-%d"),
-    normalize: bool = True,
     export: str = "",
 ):
     """Display volume stock prices. [Source: Yahoo Finance]
 
     Parameters
     ----------
-    ticker : str
-        Base ticker
     similar_tickers : List[str]
         List of similar tickers
     start : str, optional
@@ -111,28 +101,17 @@ def display_volume(
     export : str, optional
         Format to export historical prices, by default ""
     """
-    ordered_tickers = [ticker, *similar_tickers]
-    df_similar = yahoo_finance_model.get_historical(ticker, similar_tickers, start, "v")
-    # To plot with ticker first
-    df_similar = df_similar[ordered_tickers]
+    df_similar = yahoo_finance_model.get_historical(similar_tickers, start, "v")
+    df_similar = df_similar[similar_tickers]
 
     fig, ax = plt.subplots(figsize=plot_autoscale(), dpi=PLOT_DPI)
-    # This puts everything on 0-1 scale for visualizing
-    if normalize:
-        mm_scale = MinMaxScaler()
-        df_similar = pd.DataFrame(
-            mm_scale.fit_transform(df_similar),
-            columns=df_similar.columns,
-            index=df_similar.index,
-        )
-    else:
-        df_similar = df_similar.div(1_000_000)
+    df_similar = df_similar.div(1_000_000)
 
     df_similar.plot(ax=ax)
-    ax.set_title("Volume over time")
+    ax.set_title(f"Historical volume of {', '.join(similar_tickers)}")
     # ax.plot(df_similar.index, df_similar[ticker].values/1_000_000)
     ax.set_xlabel("Date")
-    ax.set_ylabel(f"{['','Normalized'][normalize]} Volume {['[K]',''][normalize]}")
+    ax.set_ylabel("Volume [M]")
     ax.grid(b=True, which="major", color="#666666", linestyle="-")
     # ensures that the historical data starts from same datapoint
     ax.set_xlim([df_similar.index[0], df_similar.index[-1]])
@@ -146,7 +125,6 @@ def display_volume(
 
 
 def display_correlation(
-    ticker: str,
     similar_tickers: List[str],
     start: str = (datetime.now() - timedelta(days=366)).strftime("%Y-%m-%d"),
     candle_type: str = "a",
@@ -157,8 +135,6 @@ def display_correlation(
 
     Parameters
     ----------
-    ticker : str
-        Base ticker
     similar_tickers : List[str]
         List of similar tickers
     start : str, optional
@@ -166,12 +142,9 @@ def display_correlation(
     candle_type : str, optional
         OHLCA column to use, by default "a" for Adjusted Close
     """
-    ordered_tickers = [ticker, *similar_tickers]
-    df_similar = yahoo_finance_model.get_historical(
-        ticker, similar_tickers, start, candle_type
-    )
-    # To plot with ticker first
-    df_similar = df_similar[ordered_tickers]
+    df_similar = yahoo_finance_model.get_historical(similar_tickers, start, candle_type)
+    df_similar = df_similar[similar_tickers]
+
     if np.any(df_similar.isna()):
         nan_tickers = df_similar.columns[df_similar.isna().sum() >= 1].to_list()
         print(f"NaN values found in: {', '.join(nan_tickers)}.  Backfilling data")
@@ -189,6 +162,6 @@ def display_correlation(
         vmax=1,
         mask=mask,
     )
-    plt.title("Correlation Heatmap")
+    plt.title(f"Correlation Heatmap of {', '.join(similar_tickers)}")
     plt.show()
     print("")

--- a/gamestonk_terminal/stocks/comparison_analysis/yahoo_finance_view.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/yahoo_finance_view.py
@@ -68,7 +68,7 @@ def display_historical(
             index=df_similar.index,
         )
     df_similar.plot(ax=ax)
-    ax.set_title(f"Historical price of {', '.join(similar_tickers)}")
+    ax.set_title("Historical price of similar companies")
     ax.set_xlabel("Time")
     ax.set_ylabel(f"{['','Normalized'][normalize]} Share Price {['($)',''][normalize]}")
     ax.grid(b=True, which="major", color="#666666", linestyle="-")
@@ -108,7 +108,7 @@ def display_volume(
     df_similar = df_similar.div(1_000_000)
 
     df_similar.plot(ax=ax)
-    ax.set_title(f"Historical volume of {', '.join(similar_tickers)}")
+    ax.set_title("Historical volume of similar companies")
     # ax.plot(df_similar.index, df_similar[ticker].values/1_000_000)
     ax.set_xlabel("Date")
     ax.set_ylabel("Volume [M]")
@@ -162,6 +162,6 @@ def display_correlation(
         vmax=1,
         mask=mask,
     )
-    plt.title(f"Correlation Heatmap of {', '.join(similar_tickers)}")
+    plt.title("Correlation Heatmap of similar companies")
     plt.show()
     print("")

--- a/gamestonk_terminal/stocks/screener/screener_controller.py
+++ b/gamestonk_terminal/stocks/screener/screener_controller.py
@@ -18,6 +18,7 @@ from gamestonk_terminal.helper_funcs import (
 )
 from gamestonk_terminal.menu import session
 from gamestonk_terminal.portfolio.portfolio_optimization import po_controller
+from gamestonk_terminal.stocks.comparison_analysis import ca_controller
 from gamestonk_terminal.stocks.screener import (
     finviz_view,
     yahoofinance_view,
@@ -49,6 +50,7 @@ class ScreenerController:
         "performance",
         "technical",
         "po",
+        "ca",
     ]
 
     def __init__(self):
@@ -84,6 +86,7 @@ Screener:
     technical      technical (e.g. Beta, SMA50, 52W Low, RSI, Change)
     {Style.NORMAL if self.screen_tickers else Style.DIM}
 Last screened tickers: {', '.join(self.screen_tickers)}
+>   ca             take these to comparison analysis menu
 >   po             take these to portoflio optimization menu{Style.RESET_ALL}
         """
         print(help_text)
@@ -296,6 +299,14 @@ Last screened tickers: {', '.join(self.screen_tickers)}
             return None
 
         return po_controller.menu(self.screen_tickers)
+
+    def call_ca(self, _):
+        """Call the comparison analysis menu with selected tickers"""
+        if not self.screen_tickers:
+            print("Some tickers must be screened first through one of the presets!\n")
+            return None
+
+        return ca_controller.menu(self.screen_tickers)
 
 
 def menu():

--- a/gamestonk_terminal/stocks/screener/screener_controller.py
+++ b/gamestonk_terminal/stocks/screener/screener_controller.py
@@ -7,6 +7,7 @@ import configparser
 import os
 from typing import List
 
+from colorama import Style
 import matplotlib.pyplot as plt
 from prompt_toolkit.completion import NestedCompleter
 from gamestonk_terminal import feature_flags as gtff
@@ -62,30 +63,30 @@ class ScreenerController:
 
     def print_help(self):
         """Print help"""
-        print("\nScreener:")
-        print("   cls           clear screen")
-        print("   ?/help        show this menu again")
-        print("   q             quit this menu, and shows back to main menu")
-        print("   quit          quit to abandon program")
-        print("")
-        print("   view          view available presets (defaults and customs)")
-        print("   set           set one of the available presets")
-        print("")
-        print(f"PRESET: {self.preset}")
-        print("")
-        print("   historical     view historical price")
-        print("   overview       overview (e.g. Sector, Industry, Market Cap, Volume)")
-        print("   valuation      valuation (e.g. P/E, PEG, P/S, P/B, EPS this Y)")
-        print("   financial      financial (e.g. Dividend, ROA, ROE, ROI, Earnings)")
-        print("   ownership      ownership (e.g. Float, Insider Own, Short Ratio)")
-        print("   performance    performance (e.g. Perf Week, Perf YTD, Volatility M)")
-        print("   technical      technical (e.g. Beta, SMA50, 52W Low, RSI, Change)")
-        print("")
-        if self.screen_tickers:
-            print(f"Last screened tickers: {', '.join(self.screen_tickers)}")
-            print("")
-            print("   > po           portfolio optimization for last screened tickers")
-            print("")
+        help_text = f"""
+Screener:
+    cls           clear screen
+    ?/help        show this menu again
+    q             quit this menu, and shows back to main menu
+    quit          quit to abandon program
+
+    view          view available presets (defaults and customs)
+    set           set one of the available presets
+
+    PRESET: {self.preset}
+
+    historical     view historical price
+    overview       overview (e.g. Sector, Industry, Market Cap, Volume)
+    valuation      valuation (e.g. P/E, PEG, P/S, P/B, EPS this Y)
+    financial      financial (e.g. Dividend, ROA, ROE, ROI, Earnings)
+    ownership      ownership (e.g. Float, Insider Own, Short Ratio)
+    performance    performance (e.g. Perf Week, Perf YTD, Volatility M)
+    technical      technical (e.g. Beta, SMA50, 52W Low, RSI, Change)
+    {Style.NORMAL if self.screen_tickers else Style.DIM}
+Last screened tickers: {', '.join(self.screen_tickers)}
+>   po             take these to portoflio optimization menu{Style.RESET_ALL}
+        """
+        print(help_text)
 
     @staticmethod
     def view_available_presets(other_args: List[str]):
@@ -290,6 +291,10 @@ class ScreenerController:
 
     def call_po(self, _):
         """Call the portfolio optimization menu with selected tickers"""
+        if not self.screen_tickers:
+            print("Some tickers must be screened first through one of the presets!\n")
+            return None
+
         return po_controller.menu(self.screen_tickers)
 
 

--- a/gamestonk_terminal/stocks/sector_industry_analysis/financedatabase_view.py
+++ b/gamestonk_terminal/stocks/sector_industry_analysis/financedatabase_view.py
@@ -208,11 +208,11 @@ def display_bars_financials(
             plt.axvline(x=benchmark, lw=3, ls="--", c="k")
 
             if unit != " ":
-                units = f"[{unit}]"
+                units = f" [{unit}] "
             else:
-                units = ""
+                units = " "
             plt.title(
-                f"{metric_title.capitalize()} {units} with benchmark of {benchmark:.2f} {unit}"
+                f"{metric_title.capitalize()}{units}with benchmark of {benchmark:.2f} {unit}"
             )
             plt.tight_layout()
             plt.show()

--- a/gamestonk_terminal/stocks/sector_industry_analysis/sia_controller.py
+++ b/gamestonk_terminal/stocks/sector_industry_analysis/sia_controller.py
@@ -1635,12 +1635,8 @@ Returned tickers: {', '.join(self.tickers)}
 
     def call_ca(self, _):
         """Call the comparison analysis menu with selected tickers"""
-        if self.ticker:
-            if self.ticker in self.tickers:
-                self.tickers.remove(self.ticker)
-            return ca_controller.menu(
-                self.ticker, self.start, self.interval, self.stock, self.tickers
-            )
+        if self.tickers:
+            return ca_controller.menu(self.tickers)
 
         print("No main ticker loaded to go into comparison analysis menu", "\n")
 

--- a/gamestonk_terminal/stocks/stocks_controller.py
+++ b/gamestonk_terminal/stocks/stocks_controller.py
@@ -137,11 +137,11 @@ Market {('CLOSED', 'OPEN')[b_is_stock_market_open()]}
 >   scr         screener stocks, \t\t e.g. overview/performance, using preset filters
 >   ins         insider trading,         \t e.g.: latest penny stock buys, top officer purchases
 >   gov         government menu, \t\t e.g. house trading, contracts, corporate lobbying
->   ba          behavioural analysis,    \t from: reddit, stocktwits, twitter, google{dim_if_no_ticker}
+>   ba          behavioural analysis,    \t from: reddit, stocktwits, twitter, google
+>   ca          comparison analysis,     \t e.g.: get similar, historical, correlation, financials{dim_if_no_ticker}
 >   fa          fundamental analysis,    \t e.g.: income, balance, cash, earnings
 >   res         research web page,       \t e.g.: macroaxis, yahoo finance, fool
 >   dd          in-depth due-diligence,  \t e.g.: news, analyst, shorts, insider, sec
->   ca          comparison analysis,     \t e.g.: historical, correlation, financials
 >   bt          strategy backtester,      \t e.g.: simple ema, ema cross, rsi strategies
 >   ta          technical analysis,      \t e.g.: ema, macd, rsi, adx, bbands, obv
 >   qa          quantitative analysis,   \t e.g.: decompose, cusum, residuals analysis
@@ -535,15 +535,10 @@ Market {('CLOSED', 'OPEN')[b_is_stock_market_open()]}
 
     def call_ca(self, _):
         """Process ca command"""
-        if not self.ticker:
-            print("Use 'load <ticker>' prior to this command!", "\n")
-            return
 
         from gamestonk_terminal.stocks.comparison_analysis import ca_controller
 
-        ret = ca_controller.menu(
-            self.ticker, self.start, self.interval, self.stock, list()
-        )
+        ret = ca_controller.menu([self.ticker] if self.ticker else "")
 
         if ret is False:
             self.print_help()


### PR DESCRIPTION
This PR refactors comparison analysis menu to not be dependent on a ticker, this allows that we can enter in there easily from screener (will implement after this gets merged) or sector and industry analysis.

Also, I made this menu a bit more robust and improved user experience. Towards a beast of a Gamestonk Terminal 1.0 🚀 