### PR TITLE
Improve UI for intraday plotly candle

### DIFF
--- a/gamestonk_terminal/stocks/stocks_controller.py
+++ b/gamestonk_terminal/stocks/stocks_controller.py
@@ -347,6 +347,7 @@ Market {('CLOSED', 'OPEN')[b_is_stock_market_open()]}
                 s_ticker=self.ticker,
                 df_stock=df_stock,
                 use_matplotlib=ns_parser.matplotlib,
+                intraday=self.interval != "1440min",
             )
 
     @try_except

--- a/gamestonk_terminal/stocks/stocks_helper.py
+++ b/gamestonk_terminal/stocks/stocks_helper.py
@@ -484,7 +484,9 @@ def load(
         return [s_ticker, s_start, s_interval, df_stock]
 
 
-def display_candle(s_ticker: str, df_stock: pd.DataFrame, use_matplotlib: bool):
+def display_candle(
+    s_ticker: str, df_stock: pd.DataFrame, use_matplotlib: bool, intraday: bool = False
+):
     """Shows candle plot of loaded ticker. [Source: Yahoo Finance, IEX Cloud or Alpha Vantage]
 
     Parameters
@@ -495,6 +497,8 @@ def display_candle(s_ticker: str, df_stock: pd.DataFrame, use_matplotlib: bool):
         Ticker name
     use_matplotlib: bool
         Flag to use matplotlib instead of interactive plotly chart
+    intraday: bool
+        Flag for intraday data for plotly range breaks
     """
     df_stock["ma20"] = df_stock["Close"].rolling(20).mean().fillna(method="bfill")
     df_stock["ma50"] = df_stock["Close"].rolling(50).mean().fillna(method="bfill")
@@ -658,6 +662,13 @@ def display_candle(s_ticker: str, df_stock: pd.DataFrame, use_matplotlib: bool):
                 type="date",
             ),
         )
+        if intraday:
+            fig.update_xaxes(
+                rangebreaks=[
+                    dict(bounds=["sat", "mon"]),
+                    dict(bounds=[16, 9.5], pattern="hour"),
+                ]
+            )
 
         fig.show()
     print("")


### PR DESCRIPTION
This PR adds a small improvement to `candle`.  When a ticker is loaded with intraday data, I add range breaks to plotly to only show M-F 930AM-4PM.

Need someone to test that plotly doesn't get weird with timezones...
Was:

![Screen_Shot_2021-12-06_at_6 26 11_AM](https://user-images.githubusercontent.com/18151143/144870057-10ffbb4b-4d72-43f5-ba8a-430ed26e80ab.png)

Now:
<img width="1463" alt="Screen Shot 2021-12-06 at 10 06 07 AM" src="https://user-images.githubusercontent.com/18151143/144869929-b5cab05a-2dba-4f67-a3bd-d4346c73001d.png">

