### PR TITLE
Fixing Linting

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
           key: ${{ runner.os }}-linting
           restore-keys: ${{ runner.os }}-linting
 
-      - run: pip install bandit black codespell flake8 mypy==0.910 pyupgrade safety pylint==2.11.1
+      - run: pip install bandit black codespell flake8 mypy pyupgrade safety pylint==2.11.1
       - run: pip install types-pytz types-requests types-termcolor types-tabulate types-PyYAML types-python-dateutil
       - run: bandit -x ./tests -r . || true
       - run: black --check .

--- a/gamestonk_terminal/cryptocurrency/crypto_controller.py
+++ b/gamestonk_terminal/cryptocurrency/crypto_controller.py
@@ -159,7 +159,7 @@ What do you want to do?
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/crypto_controller.py
+++ b/gamestonk_terminal/cryptocurrency/crypto_controller.py
@@ -157,7 +157,9 @@ What do you want to do?
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/defi/defi_controller.py
+++ b/gamestonk_terminal/cryptocurrency/defi/defi_controller.py
@@ -98,7 +98,7 @@ class DefiController:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, *_):

--- a/gamestonk_terminal/cryptocurrency/defi/defi_controller.py
+++ b/gamestonk_terminal/cryptocurrency/defi/defi_controller.py
@@ -96,7 +96,9 @@ class DefiController:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, *_):

--- a/gamestonk_terminal/cryptocurrency/discovery/discovery_controller.py
+++ b/gamestonk_terminal/cryptocurrency/discovery/discovery_controller.py
@@ -113,7 +113,9 @@ CoinMarketCap:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/discovery/discovery_controller.py
+++ b/gamestonk_terminal/cryptocurrency/discovery/discovery_controller.py
@@ -115,7 +115,7 @@ CoinMarketCap:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/due_diligence/dd_controller.py
+++ b/gamestonk_terminal/cryptocurrency/due_diligence/dd_controller.py
@@ -182,7 +182,7 @@ Coinbase:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/due_diligence/dd_controller.py
+++ b/gamestonk_terminal/cryptocurrency/due_diligence/dd_controller.py
@@ -180,7 +180,9 @@ Coinbase:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/nft/nft_controller.py
+++ b/gamestonk_terminal/cryptocurrency/nft/nft_controller.py
@@ -99,7 +99,9 @@ nftcalendar.io:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/nft/nft_controller.py
+++ b/gamestonk_terminal/cryptocurrency/nft/nft_controller.py
@@ -101,7 +101,7 @@ nftcalendar.io:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/onchain/onchain_controller.py
+++ b/gamestonk_terminal/cryptocurrency/onchain/onchain_controller.py
@@ -126,7 +126,7 @@ class OnchainController:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, *_):

--- a/gamestonk_terminal/cryptocurrency/onchain/onchain_controller.py
+++ b/gamestonk_terminal/cryptocurrency/onchain/onchain_controller.py
@@ -124,7 +124,9 @@ class OnchainController:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, *_):

--- a/gamestonk_terminal/cryptocurrency/overview/overview_controller.py
+++ b/gamestonk_terminal/cryptocurrency/overview/overview_controller.py
@@ -149,7 +149,9 @@ WithdrawalFees:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/overview/overview_controller.py
+++ b/gamestonk_terminal/cryptocurrency/overview/overview_controller.py
@@ -151,7 +151,7 @@ WithdrawalFees:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/prediction_techniques/pred_controller.py
+++ b/gamestonk_terminal/cryptocurrency/prediction_techniques/pred_controller.py
@@ -132,7 +132,9 @@ Models:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/prediction_techniques/pred_controller.py
+++ b/gamestonk_terminal/cryptocurrency/prediction_techniques/pred_controller.py
@@ -134,7 +134,7 @@ Models:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/technical_analysis/ta_controller.py
+++ b/gamestonk_terminal/cryptocurrency/technical_analysis/ta_controller.py
@@ -153,7 +153,9 @@ Custom:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/cryptocurrency/technical_analysis/ta_controller.py
+++ b/gamestonk_terminal/cryptocurrency/technical_analysis/ta_controller.py
@@ -155,7 +155,7 @@ Custom:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/economy/economy_controller.py
+++ b/gamestonk_terminal/economy/economy_controller.py
@@ -183,7 +183,7 @@ NASDAQ DataLink (formerly Quandl):
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/economy/economy_controller.py
+++ b/gamestonk_terminal/economy/economy_controller.py
@@ -181,7 +181,9 @@ NASDAQ DataLink (formerly Quandl):
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/economy/fred/fred_controller.py
+++ b/gamestonk_terminal/economy/fred/fred_controller.py
@@ -92,7 +92,7 @@ Current Series IDs:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/economy/fred/fred_controller.py
+++ b/gamestonk_terminal/economy/fred/fred_controller.py
@@ -90,7 +90,9 @@ Current Series IDs:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/etf/etf_controller.py
+++ b/gamestonk_terminal/etf/etf_controller.py
@@ -118,7 +118,9 @@ Finance Database:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/etf/etf_controller.py
+++ b/gamestonk_terminal/etf/etf_controller.py
@@ -120,7 +120,7 @@ Finance Database:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/forex/behavioural_analysis/ba_controller.py
+++ b/gamestonk_terminal/forex/behavioural_analysis/ba_controller.py
@@ -146,7 +146,9 @@ SentimentInvestor:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/forex/behavioural_analysis/ba_controller.py
+++ b/gamestonk_terminal/forex/behavioural_analysis/ba_controller.py
@@ -148,7 +148,7 @@ SentimentInvestor:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/forex/exploratory_data_analysis/eda_controller.py
+++ b/gamestonk_terminal/forex/exploratory_data_analysis/eda_controller.py
@@ -114,7 +114,9 @@ class EdaController:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/forex/exploratory_data_analysis/eda_controller.py
+++ b/gamestonk_terminal/forex/exploratory_data_analysis/eda_controller.py
@@ -116,7 +116,7 @@ class EdaController:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/forex/forex_controller.py
+++ b/gamestonk_terminal/forex/forex_controller.py
@@ -114,7 +114,7 @@ Brokerages:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/forex/forex_controller.py
+++ b/gamestonk_terminal/forex/forex_controller.py
@@ -112,7 +112,9 @@ Brokerages:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/forex/oanda/oanda_controller.py
+++ b/gamestonk_terminal/forex/oanda/oanda_controller.py
@@ -121,7 +121,7 @@ class OandaController:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/forex/oanda/oanda_controller.py
+++ b/gamestonk_terminal/forex/oanda/oanda_controller.py
@@ -119,7 +119,9 @@ class OandaController:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/brokers/ally/ally_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/ally/ally_controller.py
@@ -87,7 +87,7 @@ Stock Information:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/brokers/ally/ally_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/ally/ally_controller.py
@@ -85,7 +85,9 @@ Stock Information:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/brokers/bro_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/bro_controller.py
@@ -80,7 +80,7 @@ Crypto Brokers:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/brokers/bro_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/bro_controller.py
@@ -78,7 +78,9 @@ Crypto Brokers:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/brokers/coinbase/coinbase_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/coinbase/coinbase_controller.py
@@ -85,7 +85,7 @@ Coinbase:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/brokers/coinbase/coinbase_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/coinbase/coinbase_controller.py
@@ -83,7 +83,9 @@ Coinbase:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/brokers/degiro/degiro_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/degiro/degiro_controller.py
@@ -365,8 +365,8 @@ class DegiroController:
 
             return getattr(
                 self,
-                known_args.cmd,
-                lambda: "Command not recognized!",
+                "call_" + known_args.cmd,
+                lambda _ : "Command not recognized!",
             )(other_args)
         except Exception as e:
             print(e)

--- a/gamestonk_terminal/portfolio/brokers/degiro/degiro_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/degiro/degiro_controller.py
@@ -366,7 +366,7 @@ class DegiroController:
             return getattr(
                 self,
                 "call_" + known_args.cmd,
-                lambda _ : "Command not recognized!",
+                lambda _: "Command not recognized!",
             )(other_args)
         except Exception as e:
             print(e)

--- a/gamestonk_terminal/portfolio/brokers/robinhood/robinhood_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/robinhood/robinhood_controller.py
@@ -85,7 +85,9 @@ Robinhood:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/brokers/robinhood/robinhood_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/robinhood/robinhood_controller.py
@@ -87,7 +87,7 @@ Robinhood:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/portfolio_analysis/pa_controller.py
+++ b/gamestonk_terminal/portfolio/portfolio_analysis/pa_controller.py
@@ -101,7 +101,9 @@ Portfolio: {self.portfolio_name or None}
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/portfolio_analysis/pa_controller.py
+++ b/gamestonk_terminal/portfolio/portfolio_analysis/pa_controller.py
@@ -103,7 +103,7 @@ Portfolio: {self.portfolio_name or None}
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/portfolio_controller.py
+++ b/gamestonk_terminal/portfolio/portfolio_controller.py
@@ -148,7 +148,7 @@ Graphs:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/portfolio_controller.py
+++ b/gamestonk_terminal/portfolio/portfolio_controller.py
@@ -146,7 +146,9 @@ Graphs:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/portfolio_optimization/po_controller.py
+++ b/gamestonk_terminal/portfolio/portfolio_optimization/po_controller.py
@@ -129,7 +129,7 @@ Mean Variance Optimization:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/portfolio/portfolio_optimization/po_controller.py
+++ b/gamestonk_terminal/portfolio/portfolio_optimization/po_controller.py
@@ -127,7 +127,9 @@ Mean Variance Optimization:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/resources/resources_controller.py
+++ b/gamestonk_terminal/resources/resources_controller.py
@@ -103,7 +103,9 @@ What do you want to do?
             print(f"The following args were unexpected: {other_args}")
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/resources/resources_controller.py
+++ b/gamestonk_terminal/resources/resources_controller.py
@@ -105,7 +105,7 @@ What do you want to do?
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/backtesting/bt_controller.py
+++ b/gamestonk_terminal/stocks/backtesting/bt_controller.py
@@ -95,7 +95,9 @@ Ticker: {self.ticker.upper()}
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/backtesting/bt_controller.py
+++ b/gamestonk_terminal/stocks/backtesting/bt_controller.py
@@ -97,7 +97,7 @@ Ticker: {self.ticker.upper()}
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/behavioural_analysis/ba_controller.py
+++ b/gamestonk_terminal/stocks/behavioural_analysis/ba_controller.py
@@ -152,7 +152,7 @@ SentimentInvestor:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/behavioural_analysis/ba_controller.py
+++ b/gamestonk_terminal/stocks/behavioural_analysis/ba_controller.py
@@ -150,7 +150,9 @@ SentimentInvestor:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
@@ -496,7 +496,9 @@ Finviz:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
@@ -498,7 +498,7 @@ Finviz:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/dark_pool_shorts/dps_controller.py
+++ b/gamestonk_terminal/stocks/dark_pool_shorts/dps_controller.py
@@ -135,7 +135,7 @@ NYSE:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/dark_pool_shorts/dps_controller.py
+++ b/gamestonk_terminal/stocks/dark_pool_shorts/dps_controller.py
@@ -133,7 +133,9 @@ NYSE:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/discovery/disc_controller.py
+++ b/gamestonk_terminal/stocks/discovery/disc_controller.py
@@ -149,7 +149,7 @@ NASDAQ Data Link (Formerly Quandl):
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/discovery/disc_controller.py
+++ b/gamestonk_terminal/stocks/discovery/disc_controller.py
@@ -147,7 +147,9 @@ NASDAQ Data Link (Formerly Quandl):
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/due_diligence/dd_controller.py
+++ b/gamestonk_terminal/stocks/due_diligence/dd_controller.py
@@ -138,7 +138,7 @@ cathiesark.com
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/due_diligence/dd_controller.py
+++ b/gamestonk_terminal/stocks/due_diligence/dd_controller.py
@@ -136,7 +136,9 @@ cathiesark.com
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/fundamental_analysis/fa_controller.py
+++ b/gamestonk_terminal/stocks/fundamental_analysis/fa_controller.py
@@ -173,7 +173,7 @@ Other Sources:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/fundamental_analysis/fa_controller.py
+++ b/gamestonk_terminal/stocks/fundamental_analysis/fa_controller.py
@@ -171,7 +171,9 @@ Other Sources:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/fundamental_analysis/financial_modeling_prep/fmp_controller.py
+++ b/gamestonk_terminal/stocks/fundamental_analysis/financial_modeling_prep/fmp_controller.py
@@ -116,7 +116,7 @@ Ticker: {self.ticker}
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/fundamental_analysis/financial_modeling_prep/fmp_controller.py
+++ b/gamestonk_terminal/stocks/fundamental_analysis/financial_modeling_prep/fmp_controller.py
@@ -114,7 +114,9 @@ Ticker: {self.ticker}
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/government/gov_controller.py
+++ b/gamestonk_terminal/stocks/government/gov_controller.py
@@ -120,7 +120,7 @@ Ticker: {self.ticker or None}{dim_no_ticker}
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/government/gov_controller.py
+++ b/gamestonk_terminal/stocks/government/gov_controller.py
@@ -118,7 +118,9 @@ Ticker: {self.ticker or None}{dim_no_ticker}
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/insider/insider_controller.py
+++ b/gamestonk_terminal/stocks/insider/insider_controller.py
@@ -301,7 +301,7 @@ Ticker: {self.ticker}
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/insider/insider_controller.py
+++ b/gamestonk_terminal/stocks/insider/insider_controller.py
@@ -299,7 +299,9 @@ Ticker: {self.ticker}
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/options/options_controller.py
+++ b/gamestonk_terminal/stocks/options/options_controller.py
@@ -188,7 +188,9 @@ Current Expiry: {self.selected_date or None}
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/options/options_controller.py
+++ b/gamestonk_terminal/stocks/options/options_controller.py
@@ -190,7 +190,7 @@ Current Expiry: {self.selected_date or None}
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/options/payoff_controller.py
+++ b/gamestonk_terminal/stocks/options/payoff_controller.py
@@ -119,7 +119,7 @@ Underlying Asset: {text}
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/options/payoff_controller.py
+++ b/gamestonk_terminal/stocks/options/payoff_controller.py
@@ -117,7 +117,9 @@ Underlying Asset: {text}
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/options/pricing_controller.py
+++ b/gamestonk_terminal/stocks/options/pricing_controller.py
@@ -95,7 +95,7 @@ Options Pricing:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/options/pricing_controller.py
+++ b/gamestonk_terminal/stocks/options/pricing_controller.py
@@ -93,7 +93,9 @@ Options Pricing:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/prediction_techniques/pred_controller.py
+++ b/gamestonk_terminal/stocks/prediction_techniques/pred_controller.py
@@ -143,7 +143,7 @@ Models:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/prediction_techniques/pred_controller.py
+++ b/gamestonk_terminal/stocks/prediction_techniques/pred_controller.py
@@ -141,7 +141,9 @@ Models:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/quantitative_analysis/qa_controller.py
+++ b/gamestonk_terminal/stocks/quantitative_analysis/qa_controller.py
@@ -157,7 +157,9 @@ Other:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_load(self, other_args: List[str]):

--- a/gamestonk_terminal/stocks/quantitative_analysis/qa_controller.py
+++ b/gamestonk_terminal/stocks/quantitative_analysis/qa_controller.py
@@ -159,7 +159,7 @@ Other:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_load(self, other_args: List[str]):

--- a/gamestonk_terminal/stocks/research/res_controller.py
+++ b/gamestonk_terminal/stocks/research/res_controller.py
@@ -115,8 +115,10 @@ Ticker: {self.ticker}
             print(f"The following args were unexpected: {other_args}")
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
-        )(None)
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
+        )(other_args)
 
     def call_help(self, _):
         """Process Help command"""

--- a/gamestonk_terminal/stocks/research/res_controller.py
+++ b/gamestonk_terminal/stocks/research/res_controller.py
@@ -117,7 +117,7 @@ Ticker: {self.ticker}
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/screener/screener_controller.py
+++ b/gamestonk_terminal/stocks/screener/screener_controller.py
@@ -239,7 +239,9 @@ Last screened tickers: {', '.join(self.screen_tickers)}
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/screener/screener_controller.py
+++ b/gamestonk_terminal/stocks/screener/screener_controller.py
@@ -241,7 +241,7 @@ Last screened tickers: {', '.join(self.screen_tickers)}
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/sector_industry_analysis/sia_controller.py
+++ b/gamestonk_terminal/stocks/sector_industry_analysis/sia_controller.py
@@ -287,7 +287,9 @@ Returned tickers: {', '.join(self.tickers)}
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/sector_industry_analysis/sia_controller.py
+++ b/gamestonk_terminal/stocks/sector_industry_analysis/sia_controller.py
@@ -289,7 +289,7 @@ Returned tickers: {', '.join(self.tickers)}
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/stocks_controller.py
+++ b/gamestonk_terminal/stocks/stocks_controller.py
@@ -178,7 +178,9 @@ Market {('CLOSED', 'OPEN')[b_is_stock_market_open()]}
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/stocks_controller.py
+++ b/gamestonk_terminal/stocks/stocks_controller.py
@@ -180,7 +180,7 @@ Market {('CLOSED', 'OPEN')[b_is_stock_market_open()]}
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/technical_analysis/ta_controller.py
+++ b/gamestonk_terminal/stocks/technical_analysis/ta_controller.py
@@ -177,7 +177,7 @@ Custom:
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/gamestonk_terminal/stocks/technical_analysis/ta_controller.py
+++ b/gamestonk_terminal/stocks/technical_analysis/ta_controller.py
@@ -175,7 +175,9 @@ Custom:
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/terminal.py
+++ b/terminal.py
@@ -130,7 +130,7 @@ What do you want to do?
         return getattr(
             self,
             "call_" + known_args.cmd,
-            lambda _ : "Command not recognized!",
+            lambda _: "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):

--- a/terminal.py
+++ b/terminal.py
@@ -128,7 +128,9 @@ What do you want to do?
             return None
 
         return getattr(
-            self, "call_" + known_args.cmd, lambda: "Command not recognized!"
+            self,
+            "call_" + known_args.cmd,
+            lambda _ : "Command not recognized!",
         )(other_args)
 
     def call_help(self, _):


### PR DESCRIPTION
**Reason**
New version of `mypy` (v0.920).

Generate this kind of errors with the current code :
```
gamestonk_terminal/stocks/discovery/disc_controller.py:149: error: Too many arguments for <lambda>
gamestonk_terminal/stocks/dark_pool_shorts/dps_controller.py:135: error: Too many arguments for <lambda>
gamestonk_terminal/stocks/research/res_controller.py:117: error: Too many arguments for <lambda>
...
```

This PR fixes the linting.

**Consequense**
This is done by replacing :
```python
        return getattr(
            self,
            "call_" + known_args.cmd,
            lambda: "Command not recognized!",
        )(other_args)
```

By this :
```python
        return getattr(
            self,
            "call_" + known_args.cmd,
            lambda _ : "Command not recognized!",
        )(other_args)
```