### PR TITLE
Add whatif scenario feature

### DIFF
--- a/gamestonk_terminal/stocks/backtesting/bt_view.py
+++ b/gamestonk_terminal/stocks/backtesting/bt_view.py
@@ -3,6 +3,8 @@ __docformat__ = "numpy"
 
 import os
 
+from datetime import datetime
+import yfinance as yf
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
@@ -16,6 +18,75 @@ from gamestonk_terminal.stocks.backtesting import bt_model
 register_matplotlib_converters()
 
 np.seterr(divide="ignore")
+
+
+def display_whatif_scenario(
+    ticker: str,
+    num_shares_acquired: float,
+    date_shares_acquired: datetime,
+):
+    """Display what if scenario
+
+    Parameters
+    ----------
+    ticker: str
+        Ticker to check what if scenario
+    num_shares: float
+        Number of shares acquired
+    date_shares_acquired: str
+        Date at which the shares were acquired
+    """
+    data = yf.download(ticker, progress=False)
+
+    if not data.empty:
+        data = data["Adj Close"]
+
+    ipo_date = data.index[0]
+    last_date = data.index[-1]
+
+    if not date_shares_acquired:
+        date_shares_acquired = ipo_date
+        print("IPO date selected by default.")
+
+    if date_shares_acquired > last_date:
+        print("The date selected is in the future. Select a valid date.", "\n")
+        return
+
+    if date_shares_acquired < ipo_date:
+        print(
+            f"{ticker} had not IPO at that date. Thus, changing the date to IPO on the {ipo_date.strftime('%Y-%m-%d')}",
+            "\n",
+        )
+        date_shares_acquired = ipo_date
+
+    initial_shares_value = (
+        data[data.index > date_shares_acquired].values[0] * num_shares_acquired
+    )
+
+    if (num_shares_acquired - int(num_shares_acquired)) > 0:
+        nshares = round(num_shares_acquired, 2)
+    else:
+        nshares = round(num_shares_acquired)
+
+    shares = "share"
+    these = "This"
+    if nshares > 1:
+        shares += "s"
+        these = "These"
+
+    print(
+        f"If you had acquired {nshares} {shares} of {ticker} on "
+        f"{date_shares_acquired.strftime('%Y-%m-%d')} with a cost of {initial_shares_value:.2f}."
+    )
+
+    current_shares_value = (
+        data[data.index > date_shares_acquired].values[-1] * num_shares_acquired
+    )
+    increase_pct = 100 * current_shares_value / initial_shares_value
+    print(
+        f"{these} would be worth {current_shares_value:.2f}. Which represents an increase of {increase_pct:.2f}%.",
+        "\n",
+    )
 
 
 def display_simple_ema(

--- a/scripts/test_stocks_bt.gst
+++ b/scripts/test_stocks_bt.gst
@@ -1,0 +1,9 @@
+stocks
+load tsla
+bt
+whatif
+whatif -n 2.34
+whatif 2021-01-01
+ema
+ema_cross
+rsi

--- a/tests/gamestonk_terminal/stocks/backtesting/txt/test_bt_controller/test_print_help.txt
+++ b/tests/gamestonk_terminal/stocks/backtesting/txt/test_bt_controller/test_print_help.txt
@@ -1,6 +1,7 @@
 
-Backtesting:
 Ticker: TSLA
+
+    whatif      what if you had bought X shares on day Y
 
     ema         buy when price exceeds EMA(l)
     ema_cross   buy when EMA(short) > EMA(long)

--- a/website/content/stocks/backtesting/whatif/_index.md
+++ b/website/content/stocks/backtesting/whatif/_index.md
@@ -1,0 +1,31 @@
+```
+usage: whatif [-d DATE_SHARES_ACQUIRED] [-n NUM_SHARES_ACQUIRED] [-h]
+```
+
+Displays what if scenario of having bought X shares at date Y
+
+```
+optional arguments:
+  -d DATE_SHARES_ACQUIRED, --date DATE_SHARES_ACQUIRED
+                        Date at which the shares were acquired (default: None)
+  -n NUM_SHARES_ACQUIRED, --number NUM_SHARES_ACQUIRED
+                        Number of shares acquired (default: 1.0)
+  -h, --help            show this help message (default: False)
+```
+
+```
+
+(✨) /stocks/bt/ $ whatif -n 2
+IPO date selected by default.
+If you had acquired 2 shares of TSLA on 2010-06-29 with a cost of 9.56.
+These would be worth 2129.58. Which represents an increase of 22285.28%. 
+
+(✨) /stocks/bt/ $ whatif 2021-01-01
+If you had acquired 1 share of TSLA on 2021-01-01 with a cost of 729.77.
+This would be worth 1065.45. Which represents an increase of 146.00%. 
+
+(✨) /stocks/bt/ $ whatif
+IPO date selected by default.
+If you had acquired 1 share of TSLA on 2010-06-29 with a cost of 4.78.
+This would be worth 1065.28. Which represents an increase of 22295.52%. 
+```

--- a/website/data/menu/main.yml
+++ b/website/data/menu/main.yml
@@ -381,6 +381,8 @@ main:
       - name: backtesting
         ref: "/stocks/backtesting"
         sub:
+          - name: whatif
+            ref: "/stocks/backtesting/whatif"
           - name: ema
             ref: "/stocks/backtesting/ema"
           - name: ema_cross


### PR DESCRIPTION
```
(✨) /stocks/bt/ $ whatif
IPO date selected by default.
If you had acquired 1 share of TSLA on 2010-06-29 with a cost of 4.78.
This would be worth 1063.05. Which represents an increase of 22248.85%. 

(✨) /stocks/bt/ $ whatif -n 2.34
IPO date selected by default.
If you had acquired 2.34 shares of TSLA on 2010-06-29 with a cost of 11.18.
These would be worth 2486.98. Which represents an increase of 22243.83%. 

(✨) /stocks/bt/ $ whatif 2021-01-01
If you had acquired 1 share of TSLA on 2021-01-01 with a cost of 729.77.
This would be worth 1062.81. Which represents an increase of 145.64%. 
```