### PR TITLE
Handle KeyboardInterrupt on user input read

### DIFF
--- a/gamestonk_terminal/cryptocurrency/crypto_controller.py
+++ b/gamestonk_terminal/cryptocurrency/crypto_controller.py
@@ -864,11 +864,16 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and crypto_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /crypto/ $ ",
-                    completer=crypto_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /crypto/ $ ",
+                        completer=crypto_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
+
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /crypto/ $ ")

--- a/gamestonk_terminal/cryptocurrency/defi/defi_controller.py
+++ b/gamestonk_terminal/cryptocurrency/defi/defi_controller.py
@@ -779,11 +779,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and defi_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /crypto/defi/ $ ",
-                    completer=defi_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /crypto/defi/ $ ",
+                        completer=defi_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /crypto/defi/ $ ")

--- a/gamestonk_terminal/cryptocurrency/discovery/discovery_controller.py
+++ b/gamestonk_terminal/cryptocurrency/discovery/discovery_controller.py
@@ -1227,11 +1227,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and disc_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /crypto/disc/ $ ",
-                    completer=disc_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /crypto/disc/ $ ",
+                        completer=disc_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /crypto/disc/ $ ")

--- a/gamestonk_terminal/cryptocurrency/due_diligence/dd_controller.py
+++ b/gamestonk_terminal/cryptocurrency/due_diligence/dd_controller.py
@@ -1533,11 +1533,15 @@ def menu(coin=None, source=None, symbol=None, queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and dd_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /crypto/dd/ $ ",
-                    completer=dd_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /crypto/dd/ $ ",
+                        completer=dd_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /crypto/dd/ $ ")

--- a/gamestonk_terminal/cryptocurrency/nft/nft_controller.py
+++ b/gamestonk_terminal/cryptocurrency/nft/nft_controller.py
@@ -323,11 +323,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and nft_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /crypto/nft/ $ ",
-                    completer=nft_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /crypto/nft/ $ ",
+                        completer=nft_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /crypto/nft/ $ ")

--- a/gamestonk_terminal/cryptocurrency/onchain/onchain_controller.py
+++ b/gamestonk_terminal/cryptocurrency/onchain/onchain_controller.py
@@ -1381,11 +1381,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and onchain_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /crypto/onchain/ $ ",
-                    completer=onchain_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /crypto/onchain/ $ ",
+                        completer=onchain_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /crypto/onchain/ $ ")

--- a/gamestonk_terminal/cryptocurrency/overview/overview_controller.py
+++ b/gamestonk_terminal/cryptocurrency/overview/overview_controller.py
@@ -1624,11 +1624,15 @@ def menu(queue: List[str] = None):
                     c: None for c in withdrawalfees_model.POSSIBLE_CRYPTOS
                 }
                 completer = NestedCompleter.from_nested_dict(choices)
-                an_input = session.prompt(
-                    f"{get_flair()} /crypto/ov/ $ ",
-                    completer=completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /crypto/ov/ $ ",
+                        completer=completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /crypto/ov/ $ ")

--- a/gamestonk_terminal/cryptocurrency/prediction_techniques/pred_controller.py
+++ b/gamestonk_terminal/cryptocurrency/prediction_techniques/pred_controller.py
@@ -887,11 +887,15 @@ def menu(coin: str, data: pd.DataFrame, queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and pred_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /crypto/pred/ $ ",
-                    completer=pred_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /crypto/pred/ $ ",
+                        completer=pred_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /crypto/pred/ $ ")

--- a/gamestonk_terminal/cryptocurrency/technical_analysis/ta_controller.py
+++ b/gamestonk_terminal/cryptocurrency/technical_analysis/ta_controller.py
@@ -1138,11 +1138,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and ta_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /crypto/ta/ $ ",
-                    completer=ta_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /crypto/ta/ $ ",
+                        completer=ta_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /crypto/ta/ $ ")

--- a/gamestonk_terminal/economy/economy_controller.py
+++ b/gamestonk_terminal/economy/economy_controller.py
@@ -1183,12 +1183,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and econ_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /economy/ $ ",
-                    completer=econ_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /economy/ $ ",
+                        completer=econ_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /economy/ $ ")

--- a/gamestonk_terminal/economy/fred/fred_controller.py
+++ b/gamestonk_terminal/economy/fred/fred_controller.py
@@ -351,12 +351,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and fred_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /economy/fred/ $ ",
-                    completer=fred_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /economy/fred/ $ ",
+                        completer=fred_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /economy/fred/ $ ")

--- a/gamestonk_terminal/etf/discovery/disc_controller.py
+++ b/gamestonk_terminal/etf/discovery/disc_controller.py
@@ -261,11 +261,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and disc_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /etf/disc/ $ ",
-                    completer=disc_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /etf/disc/ $ ",
+                        completer=disc_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /etf/disc/ $ ")

--- a/gamestonk_terminal/etf/etf_controller.py
+++ b/gamestonk_terminal/etf/etf_controller.py
@@ -791,12 +791,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and etf_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /etf/ $ ",
-                    completer=etf_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /etf/ $ ",
+                        completer=etf_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /etf/ $ ")

--- a/gamestonk_terminal/etf/prediction_techniques/pred_controller.py
+++ b/gamestonk_terminal/etf/prediction_techniques/pred_controller.py
@@ -937,11 +937,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and pred_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/pred/ $ ",
-                    completer=pred_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/pred/ $ ",
+                        completer=pred_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/pred/ $ ")

--- a/gamestonk_terminal/etf/screener/screener_controller.py
+++ b/gamestonk_terminal/etf/screener/screener_controller.py
@@ -425,11 +425,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and scr_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /etf/scr/ $ ",
-                    completer=scr_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /etf/scr/ $ ",
+                        completer=scr_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /etf/scr/ $ ")

--- a/gamestonk_terminal/etf/technical_analysis/ta_controller.py
+++ b/gamestonk_terminal/etf/technical_analysis/ta_controller.py
@@ -1305,11 +1305,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and ta_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /etf/ta/ $ ",
-                    completer=ta_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /etf/ta/ $ ",
+                        completer=ta_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /etf/ta/ $ ")

--- a/gamestonk_terminal/forex/forex_controller.py
+++ b/gamestonk_terminal/forex/forex_controller.py
@@ -367,11 +367,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and forex_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /forex/ $ ",
-                    completer=forex_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /forex/ $ ",
+                        completer=forex_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /forex/ $ ")

--- a/gamestonk_terminal/forex/oanda/oanda_controller.py
+++ b/gamestonk_terminal/forex/oanda/oanda_controller.py
@@ -647,11 +647,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and oanda_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /forex/oanda/ $ ",
-                    completer=oanda_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /forex/oanda/ $ ",
+                        completer=oanda_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /forex/oanda/ $ ")

--- a/gamestonk_terminal/mutual_funds/mutual_fund_controller.py
+++ b/gamestonk_terminal/mutual_funds/mutual_fund_controller.py
@@ -538,12 +538,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and fund_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /funds/ $ ",
-                    completer=fund_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /funds/ $ ",
+                        completer=fund_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /funds/ $ ")

--- a/gamestonk_terminal/portfolio/brokers/ally/ally_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/ally/ally_controller.py
@@ -313,12 +313,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and ally_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /portfolio/bro/ally/ $ ",
-                    completer=ally_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /portfolio/bro/ally/ $ ",
+                        completer=ally_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /portfolio/bro/ally/ $ ")

--- a/gamestonk_terminal/portfolio/brokers/bro_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/bro_controller.py
@@ -233,12 +233,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and bro_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /portfolio/bro/ $ ",
-                    completer=bro_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /portfolio/bro/ $ ",
+                        completer=bro_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /portfolio/bro/ $ ")

--- a/gamestonk_terminal/portfolio/brokers/coinbase/coinbase_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/coinbase/coinbase_controller.py
@@ -374,12 +374,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and cb_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /portfolio/bro/cb/ $ ",
-                    completer=cb_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /portfolio/bro/cb/ $ ",
+                        completer=cb_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /portfolio/bro/cb/ $ ")

--- a/gamestonk_terminal/portfolio/brokers/degiro/degiro_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/degiro/degiro_controller.py
@@ -459,12 +459,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and degiro_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /portfolio/bro/degiro/ $ ",
-                    completer=degiro_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /portfolio/bro/degiro/ $ ",
+                        completer=degiro_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /portfolio/bro/degiro/ $ ")

--- a/gamestonk_terminal/portfolio/brokers/robinhood/robinhood_controller.py
+++ b/gamestonk_terminal/portfolio/brokers/robinhood/robinhood_controller.py
@@ -245,12 +245,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and rh_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /portfolio/bro/rh/ $ ",
-                    completer=rh_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /portfolio/bro/rh/ $ ",
+                        completer=rh_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /portfolio/bro/rh/ $ ")

--- a/gamestonk_terminal/portfolio/portfolio_analysis/pa_controller.py
+++ b/gamestonk_terminal/portfolio/portfolio_analysis/pa_controller.py
@@ -265,10 +265,14 @@ def menu():
             completer = NestedCompleter.from_nested_dict(
                 {c: None for c in pa_controller.CHOICES}
             )
-            an_input = session.prompt(
-                f"{get_flair()} (portfolio)>(pa)> ",
-                completer=completer,
-            )
+            try:
+                an_input = session.prompt(
+                    f"{get_flair()} (portfolio)>(pa)> ",
+                    completer=completer,
+                )
+            except KeyboardInterrupt:
+                # Exit in case of keyboard interrupt
+                an_input = "exit"
         else:
             an_input = input(f"{get_flair()} (portfolio)>(pa)> ")
 

--- a/gamestonk_terminal/portfolio/portfolio_controller.py
+++ b/gamestonk_terminal/portfolio/portfolio_controller.py
@@ -480,12 +480,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and port_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /portfolio/ $ ",
-                    completer=port_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /portfolio/ $ ",
+                        completer=port_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /portfolio/ $ ")

--- a/gamestonk_terminal/portfolio/portfolio_optimization/po_controller.py
+++ b/gamestonk_terminal/portfolio/portfolio_optimization/po_controller.py
@@ -941,12 +941,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and po_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /portfolio/po/ $ ",
-                    completer=po_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /portfolio/po/ $ ",
+                        completer=po_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /portfolio/po/ $ ")

--- a/gamestonk_terminal/reports/reports_controller.py
+++ b/gamestonk_terminal/reports/reports_controller.py
@@ -301,12 +301,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and report_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /reports/ $ ",
-                    completer=report_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /reports/ $ ",
+                        completer=report_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /reports/ $ ")

--- a/gamestonk_terminal/resources/resources_controller.py
+++ b/gamestonk_terminal/resources/resources_controller.py
@@ -219,12 +219,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and rc_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /resources/ $ ",
-                    completer=rc_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /resources/ $ ",
+                        completer=rc_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /resources/ $ ")

--- a/gamestonk_terminal/stocks/backtesting/bt_controller.py
+++ b/gamestonk_terminal/stocks/backtesting/bt_controller.py
@@ -414,12 +414,15 @@ def menu(ticker: str, stock: pd.DataFrame, queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and bt_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/bt/ $ ",
-                    completer=bt_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/bt/ $ ",
+                        completer=bt_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/bt/ $ ")

--- a/gamestonk_terminal/stocks/behavioural_analysis/ba_controller.py
+++ b/gamestonk_terminal/stocks/behavioural_analysis/ba_controller.py
@@ -1130,11 +1130,15 @@ def menu(ticker: str, start: datetime, queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and ba_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/ba/ $ ",
-                    completer=ba_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/ba/ $ ",
+                        completer=ba_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/ba/ $ ")

--- a/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
@@ -1092,12 +1092,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and ca_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/ca/ $ ",
-                    completer=ca_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/ca/ $ ",
+                        completer=ca_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/ca/ $ ")

--- a/gamestonk_terminal/stocks/dark_pool_shorts/dps_controller.py
+++ b/gamestonk_terminal/stocks/dark_pool_shorts/dps_controller.py
@@ -716,12 +716,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and dps_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/dps/ $ ",
-                    completer=dps_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/dps/ $ ",
+                        completer=dps_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/dps/ $ ")

--- a/gamestonk_terminal/stocks/discovery/disc_controller.py
+++ b/gamestonk_terminal/stocks/discovery/disc_controller.py
@@ -924,11 +924,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and disc_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/disc/ $ ",
-                    completer=disc_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/disc/ $ ",
+                        completer=disc_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/disc/ $ ")

--- a/gamestonk_terminal/stocks/due_diligence/dd_controller.py
+++ b/gamestonk_terminal/stocks/due_diligence/dd_controller.py
@@ -583,11 +583,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and dd_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/dd/ $ ",
-                    completer=dd_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/dd/ $ ",
+                        completer=dd_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/dd/ $ ")

--- a/gamestonk_terminal/stocks/fundamental_analysis/fa_controller.py
+++ b/gamestonk_terminal/stocks/fundamental_analysis/fa_controller.py
@@ -990,11 +990,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and fa_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/fa/ $ ",
-                    completer=fa_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/fa/ $ ",
+                        completer=fa_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/fa/ $ ")

--- a/gamestonk_terminal/stocks/fundamental_analysis/financial_modeling_prep/fmp_controller.py
+++ b/gamestonk_terminal/stocks/fundamental_analysis/financial_modeling_prep/fmp_controller.py
@@ -681,11 +681,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and fmp_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/fa/fmp/ $ ",
-                    completer=fmp_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/fa/fmp/ $ ",
+                        completer=fmp_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/fa/fmp/ $ ")

--- a/gamestonk_terminal/stocks/government/gov_controller.py
+++ b/gamestonk_terminal/stocks/government/gov_controller.py
@@ -707,11 +707,15 @@ def menu(ticker: str, queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and gov_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/gov/ $ ",
-                    completer=gov_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/gov/ $ ",
+                        completer=gov_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/gov/ $ ")

--- a/gamestonk_terminal/stocks/insider/insider_controller.py
+++ b/gamestonk_terminal/stocks/insider/insider_controller.py
@@ -1126,11 +1126,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and ins_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/ins/ $ ",
-                    completer=ins_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/ins/ $ ",
+                        completer=ins_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/ins/ $ ")

--- a/gamestonk_terminal/stocks/options/options_controller.py
+++ b/gamestonk_terminal/stocks/options/options_controller.py
@@ -1382,12 +1382,15 @@ def menu(ticker: str = "", queue: List[str] = None):
                         }
 
                 completer = NestedCompleter.from_nested_dict(op_controller.choices)
-
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/options/ $ ",
-                    completer=completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/options/ $ ",
+                        completer=completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/options/ $ ")

--- a/gamestonk_terminal/stocks/options/payoff_controller.py
+++ b/gamestonk_terminal/stocks/options/payoff_controller.py
@@ -441,11 +441,15 @@ def menu(ticker: str, expiration: str, queue: List[str] = None):
                         str(c): {} for c in range(len(payoff_controller.options))
                     }
                 completer = NestedCompleter.from_nested_dict(payoff_controller.choices)
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/options/payoff/ $ ",
-                    completer=completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/options/payoff/ $ ",
+                        completer=completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/options/payoff/ $ ")

--- a/gamestonk_terminal/stocks/options/pricing_controller.py
+++ b/gamestonk_terminal/stocks/options/pricing_controller.py
@@ -372,11 +372,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and pricing_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/options/pricing/ $ ",
-                    completer=pricing_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/options/pricing/ $ ",
+                        completer=pricing_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/options/pricing/ $ ")

--- a/gamestonk_terminal/stocks/options/screener_controller.py
+++ b/gamestonk_terminal/stocks/options/screener_controller.py
@@ -332,11 +332,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and scr_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/options/screen/ $ ",
-                    completer=scr_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/options/screen/ $ ",
+                        completer=scr_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/options/screen/ $ ")

--- a/gamestonk_terminal/stocks/prediction_techniques/pred_controller.py
+++ b/gamestonk_terminal/stocks/prediction_techniques/pred_controller.py
@@ -937,11 +937,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and pred_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/pred/ $ ",
-                    completer=pred_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/pred/ $ ",
+                        completer=pred_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/pred/ $ ")

--- a/gamestonk_terminal/stocks/quantitative_analysis/qa_controller.py
+++ b/gamestonk_terminal/stocks/quantitative_analysis/qa_controller.py
@@ -910,12 +910,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and qa_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/qa/ $ ",
-                    completer=qa_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/qa/ $ ",
+                        completer=qa_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/qa/ $ ")

--- a/gamestonk_terminal/stocks/research/res_controller.py
+++ b/gamestonk_terminal/stocks/research/res_controller.py
@@ -339,11 +339,15 @@ def menu(ticker: str, start: datetime, interval: str, queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and res_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/res/ $ ",
-                    completer=res_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/res/ $ ",
+                        completer=res_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/res/ $ ")

--- a/gamestonk_terminal/stocks/screener/screener_controller.py
+++ b/gamestonk_terminal/stocks/screener/screener_controller.py
@@ -792,11 +792,15 @@ def menu(queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and scr_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/scr/ $ ",
-                    completer=scr_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/scr/ $ ",
+                        completer=scr_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/scr/ $ ")

--- a/gamestonk_terminal/stocks/sector_industry_analysis/sia_controller.py
+++ b/gamestonk_terminal/stocks/sector_industry_analysis/sia_controller.py
@@ -1108,12 +1108,15 @@ def menu(
                     )
                 }
                 completer = NestedCompleter.from_nested_dict(sia_controller.choices)
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/sia/ $ ",
-                    completer=completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/sia/ $ ",
+                        completer=completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/sia/ $ ")

--- a/gamestonk_terminal/stocks/stocks_controller.py
+++ b/gamestonk_terminal/stocks/stocks_controller.py
@@ -725,12 +725,15 @@ def menu(ticker: str = "", queue: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and stocks_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/ $ ",
-                    completer=stocks_controller.completer,
-                    search_ignore_case=True,
-                )
-
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/ $ ",
+                        completer=stocks_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/ $ ")

--- a/gamestonk_terminal/stocks/technical_analysis/ta_controller.py
+++ b/gamestonk_terminal/stocks/technical_analysis/ta_controller.py
@@ -1563,11 +1563,15 @@ def menu(
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT and ta_controller.completer:
-                an_input = session.prompt(
-                    f"{get_flair()} /stocks/ta/ $ ",
-                    completer=ta_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} /stocks/ta/ $ ",
+                        completer=ta_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    # Exit in case of keyboard interrupt
+                    an_input = "exit"
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} /stocks/ta/ $ ")

--- a/gamestonk_terminal/terminal_helper.py
+++ b/gamestonk_terminal/terminal_helper.py
@@ -314,7 +314,7 @@ def print_goodbye():
         goodbye_msg[random.randint(0, len(goodbye_msg) - 1)] + goodbye_msg_time + "\n"
     )
 
-    logger.info("Terminal started")
+    logger.info("Terminal stopped")
 
 
 def sha256sum(filename):

--- a/terminal.py
+++ b/terminal.py
@@ -73,7 +73,6 @@ class TerminalController:
             "cmd",
             choices=self.CHOICES,
         )
-
         self.completer: Union[None, NestedCompleter] = None
 
         if session and gtff.USE_PROMPT_TOOLKIT:
@@ -287,10 +286,8 @@ def terminal(jobs_cmds: List[str] = None):
         if t_controller.queue and len(t_controller.queue) > 0:
             # If the command is quitting the menu we want to return in here
             if t_controller.queue[0] in ("q", "..", "quit"):
-                print("")
-                if len(t_controller.queue) > 1:
-                    return t_controller.queue[1:]
-                return []
+                print_goodbye()
+                break
 
             # Consume 1 element from the queue
             an_input = t_controller.queue[0]
@@ -308,11 +305,15 @@ def terminal(jobs_cmds: List[str] = None):
 
             # Get input from user using auto-completion
             if session and gtff.USE_PROMPT_TOOLKIT:
-                an_input = session.prompt(
-                    f"{get_flair()} / $ ",
-                    completer=t_controller.completer,
-                    search_ignore_case=True,
-                )
+                try:
+                    an_input = session.prompt(
+                        f"{get_flair()} / $ ",
+                        completer=t_controller.completer,
+                        search_ignore_case=True,
+                    )
+                except KeyboardInterrupt:
+                    print_goodbye()
+                    break
             # Get input from user without auto-completion
             else:
                 an_input = input(f"{get_flair()} / $ ")
@@ -320,7 +321,6 @@ def terminal(jobs_cmds: List[str] = None):
         try:
             # Process the input command
             t_controller.queue = t_controller.switch(an_input)
-
             if an_input in ("q", "quit", "..", "exit"):
                 print_goodbye()
                 break


### PR DESCRIPTION
Add keyboard interrupt exception in order to handle ctrl+c gracefully.
A typo in print_goodbye corrected at the same time.

This PR was previously closed here: https://github.com/GamestonkTerminal/GamestonkTerminal/pull/1121 and can't be reopen since branch was rebased.