### PR TITLE
Updating tests : conftest

### DIFF
--- a/tests/FIXTURES.md
+++ b/tests/FIXTURES.md
@@ -159,6 +159,16 @@ You can run this command to regenerate the text file :
 pytest --record-mode=rewrite
 ```
 
+**REWRITE EXPECTED**
+
+This will force `record_stdout` to rewrite any changed file (`txt`).
+
+This will not rewrite the cassettes.
+
+Example :
+```
+pytest --rewrite-expected
+```
 
 **VCR**
 
@@ -283,6 +293,17 @@ You can run this command to regenerate the text file :
 
 ```bash
 pytest --record-mode=rewrite
+```
+
+**REWRITE EXPECTED**
+
+This will force `recorder` to rewrite any changed file (`csv`, `json`, `txt`).
+
+This will not rewrite the cassettes.
+
+Example :
+```
+pytest --rewrite-expected
 ```
 
 **VCR**

--- a/tests/README.md
+++ b/tests/README.md
@@ -318,6 +318,20 @@ def test_ark_orders_view(kwargs_dict, mocker, use_color):
     yf.download(tickers="VCYT QSI")
 ```
 
+**BROTLI**
+
+The library `requests` doesn't support : `brotli` comnpression.
+
+Unless `brotli` library is installed in the enviroment.
+
+Plus `brotli` is not in `GamestonkTerminal` requirements.
+
+So if both of these conditions are fulfilled :
+- one generates a cassette with `brotli` installed in his/her environment
+- the server choose to send `brotli` compressed data
+
+Then the `test` might work in local but crash during `PullRequest`.
+
 ## 3.9. List of useful `vscode` tools for `unit tests`
 
 **VSCODE TESTING**

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,6 @@ import pandas as pd
 import pytest
 from _pytest.config.argparsing import Parser
 
-# from pytest_recording._vcr import merge_kwargs
 from _pytest.capture import MultiCapture, SysCapture
 from _pytest.config import Config
 from _pytest.fixtures import SubRequest
@@ -165,6 +164,14 @@ class Recorder:
         self.__display_limit = display_limit
 
     @property
+    def rewrite_expected(self) -> bool:
+        return self.__rewrite_expected
+
+    @rewrite_expected.setter
+    def rewrite_expected(self, rewrite_expected: bool):
+        self.__rewrite_expected = rewrite_expected
+
+    @property
     def path_template(self) -> PathTemplate:
         return self.__path_template
 
@@ -181,10 +188,12 @@ class Recorder:
         path_template: PathTemplate,
         record_mode: str,
         display_limit: int = DISPLAY_LIMIT,
+        rewrite_expected: bool = False,
     ) -> None:
         self.__path_template = path_template
         self.__record_mode = record_mode
         self.__display_limit = display_limit
+        self.__rewrite_expected = rewrite_expected
 
         self.__record_list: List[Record] = list()
 
@@ -227,6 +236,7 @@ class Recorder:
     def persist(self):
         record_list = self.__record_list
         record_mode = self.__record_mode
+        rewrite_expected = self.__rewrite_expected
 
         for record in record_list:
             if record_mode == "all":
@@ -245,7 +255,7 @@ class Recorder:
             else:
                 raise Exception(f"Unknown `record-mode` : {record_mode}")
 
-            if save:
+            if save or rewrite_expected:
                 record.persist()
 
 
@@ -283,10 +293,21 @@ def pytest_addoption(parser: Parser):
         action="store_true",
         help="To run tests with the marker : @pytest.mark.prediction",
     )
+    parser.addoption(
+        "--rewrite-expected",
+        action="store_true",
+        help="To force `record_stdout` and `recorder` to rewrite all files.",
+    )
 
 
 def pytest_configure(config: Config) -> None:
     config.addinivalue_line("markers", "record_stdout: Mark the test as text record.")
+
+
+@pytest.fixture(scope="session")  # type: ignore
+def rewrite_expected(request: SubRequest) -> bool:
+    """Force rewriting of all expected data by : `record_stdout` and `recorder`."""
+    return request.config.getoption("--rewrite-expected")
 
 
 @pytest.fixture
@@ -313,7 +334,7 @@ def record_stdout_markers(request: SubRequest) -> List[Mark]:
 
 
 def merge_markers_kwargs(markers: List[Mark]) -> Dict[str, Any]:
-    """Merge all kwargs into a single dictionary to pass to `vcr.use_cassette`."""
+    """Merge all kwargs into a single dictionary."""
     kwargs: Dict[str, Any] = dict()
     for marker in reversed(markers):
         kwargs.update(marker.kwargs)
@@ -341,6 +362,7 @@ def record_stdout_format_kwargs(
 @pytest.fixture(autouse=True)
 def record_stdout(
     disable_recording: bool,
+    rewrite_expected: bool,
     record_stdout_markers: List[Mark],
     record_mode: str,
     request: SubRequest,
@@ -372,6 +394,7 @@ def record_stdout(
             path_template=path_template,
             record_mode=formatted_kwargs["record_mode"],
             display_limit=formatted_kwargs["display_limit"],
+            rewrite_expected=rewrite_expected,
         )
 
         # CAPTURE STDOUT
@@ -409,6 +432,7 @@ def record_stdout(
 @pytest.fixture
 def recorder(
     disable_recording: bool,
+    rewrite_expected: bool,
     record_mode: str,
     request: SubRequest,
 ):
@@ -428,7 +452,9 @@ def recorder(
             "You can't combine both of these fixtures : `record_stdout marker`, `recorder`."
         )
     else:
-        recorder = Recorder(path_template, record_mode)
+        recorder = Recorder(
+            path_template, record_mode, rewrite_expected=rewrite_expected
+        )
         yield recorder
         recorder.persist()
         recorder.assert_equal()


### PR DESCRIPTION
**Reason**
Allow forcing the update of all the stored expected output (`csv`, `json`, `txt`) generate by these fixtures :
- `recorder`
- `record_stdout`