### PR TITLE
Show Plotly in PYQT Window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ exports/*
 .idea
 .coverage
 htmlcov
+name.html
 gamestonk_terminal/reports
 gamestonk_terminal/jupyter/reports/stored/*
 !gamestonk_terminal/jupyter/reports/stored/.gitkeep

--- a/discordbot/requirements.txt
+++ b/discordbot/requirements.txt
@@ -2,15 +2,15 @@ aiohttp==3.7.4.post0; python_full_version >= "3.5.3" and python_version >= "3.6"
 alabaster==0.7.12; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.6"
 alpha-vantage==2.3.1
 ansiwrap==0.8.4; python_version >= "3.6"
-anyio==3.4.0; python_full_version >= "3.6.2" and python_version >= "3.6"
+anyio==3.5.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 appdirs==1.4.4; python_full_version >= "3.6.2" and python_version >= "3.6"
 appnope==0.1.2; platform_system == "Darwin" and python_version >= "3.7" and sys_platform == "darwin"
-argon2-cffi-bindings==21.2.0; python_version >= "3.6"
-argon2-cffi==21.3.0; python_version >= "3.6"
-astroid==2.9.2; python_full_version >= "3.6.2"
+argon2-cffi-bindings==21.2.0; python_version >= "3.7"
+argon2-cffi==21.3.0; python_version >= "3.7"
+astroid==2.9.3; python_full_version >= "3.6.2"
 async-timeout==3.0.1; python_full_version >= "3.5.3" and python_version >= "3.6"
 atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0"
-attrs==21.4.0; python_full_version >= "3.6.1" and python_version >= "3.6" and python_version < "4.0"
+attrs==21.4.0; python_full_version >= "3.7.0" and python_version >= "3.6" and python_version < "4.0"
 babel==2.9.1; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6")
 backcall==0.2.0; python_version >= "3.7"
 backports.zoneinfo==0.2.1; python_version < "3.9" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
@@ -22,7 +22,7 @@ bleach==4.1.0; python_version >= "3.7"
 bs4==0.0.1
 bt==0.2.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 certifi==2021.10.8; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0") and (python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3")
-cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.6.1"
+cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 cfgv==3.3.1; python_full_version >= "3.6.1"
 chardet==4.0.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 charset-normalizer==2.0.10; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0") and (python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3")
@@ -52,7 +52,7 @@ distlib==0.3.4; python_full_version >= "3.6.1"
 dnspython==2.1.0; python_version >= "3.6"
 docutils==0.16; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
 ecos==2.0.10; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
-entrypoints==0.3; python_full_version >= "3.6.1" and python_version >= "3.7"
+entrypoints==0.3; python_full_version >= "3.7.0" and python_version >= "3.7"
 et-xmlfile==1.1.0; python_version >= "3.6"
 exchange-calendars==3.5; python_version >= "3.7" and python_full_version >= "3.7.0"
 fear-greed-index==0.1.3; python_full_version >= "3.6.8" and python_full_version < "4.0.0"
@@ -69,19 +69,19 @@ frozendict==2.1.3; python_version >= "3.6"
 fundamentalanalysis==0.2.12
 future==0.18.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 gitdb==4.0.9; python_version >= "3.7"
-gitpython==3.1.25; python_version >= "3.7"
+gitpython==3.1.26; python_version >= "3.7"
 grpcio==1.43.0; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 hijri-converter==2.2.2; python_version >= "3.6"
 holidays==0.11.3.1; python_version >= "3.6"
-identify==2.4.2; python_full_version >= "3.6.1"
-idna==3.3; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0") and (python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3")
+identify==2.4.4; python_full_version >= "3.6.1"
+idna==3.3; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0") and (python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3")
 imagesize==1.3.0; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.6"
 inflection==0.5.1; python_version >= "3.6"
 iniconfig==1.1.1; python_version >= "3.6"
 investpy==1.0.7; python_version >= "3"
-ipykernel==6.6.1; python_version >= "3.7"
+ipykernel==6.7.0; python_version >= "3.7"
 ipympl==0.8.5
-ipython-genutils==0.2.0; python_full_version >= "3.6.1" and python_version >= "3.6"
+ipython-genutils==0.2.0; python_full_version >= "3.7.0" and python_version >= "3.7"
 ipython==7.31.0; python_version >= "3.7"
 ipywidgets==7.6.5
 iso8601==0.1.16
@@ -91,15 +91,15 @@ jinja2==3.0.3; python_full_version >= "3.6.8" and python_full_version < "4.0.0" 
 joblib==1.1.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 json5==0.9.6; python_version >= "3.6"
 jsonschema==3.2.0
-jupyter-client==7.1.0; python_full_version >= "3.6.1" and python_version >= "3.7"
+jupyter-client==7.1.1; python_full_version >= "3.7.0" and python_version >= "3.7"
 jupyter-console==6.4.0; python_version >= "3.6"
-jupyter-core==4.9.1; python_full_version >= "3.6.1" and python_version >= "3.7"
-jupyter-server==1.13.1; python_version >= "3.6"
+jupyter-core==4.9.1; python_full_version >= "3.7.0" and python_version >= "3.7"
+jupyter-server==1.13.3; python_version >= "3.7"
 jupyter==1.0.0
 jupyterlab-pygments==0.1.2; python_version >= "3.7"
 jupyterlab-server==2.10.3; python_version >= "3.6"
 jupyterlab-widgets==1.0.2; python_version >= "3.6"
-jupyterlab==3.2.6; python_version >= "3.6"
+jupyterlab==3.2.8; python_version >= "3.6"
 kiwisolver==1.3.2; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.7"
 korean-lunar-calendar==0.2.1; python_version >= "3.7" and python_full_version >= "3.7.0"
 lazy-object-proxy==1.7.1; python_version >= "3.6" and python_full_version >= "3.6.2"
@@ -120,13 +120,13 @@ multitasking==0.0.10
 mypy-extensions==0.4.3; python_full_version >= "3.6.2" and python_version >= "3.6"
 mypy==0.930; python_version >= "3.6"
 myst-parser==0.15.2; python_version >= "3.6"
-nbclassic==0.3.4; python_version >= "3.6"
-nbclient==0.5.9; python_full_version >= "3.6.1" and python_version >= "3.7"
+nbclassic==0.3.5; python_version >= "3.6"
+nbclient==0.5.10; python_full_version >= "3.7.0" and python_version >= "3.7"
 nbconvert==6.4.0; python_version >= "3.7"
-nbformat==5.1.3; python_full_version >= "3.6.1" and python_version >= "3.7"
-nest-asyncio==1.5.4; python_full_version >= "3.6.1" and python_version >= "3.7"
+nbformat==5.1.3; python_full_version >= "3.7.0" and python_version >= "3.7"
+nest-asyncio==1.5.4; python_full_version >= "3.7.0" and python_version >= "3.7"
 nodeenv==1.6.0; python_full_version >= "3.6.1"
-notebook==6.4.6; python_version >= "3.6"
+notebook==6.4.7; python_version >= "3.6"
 numpy==1.21.2; python_version >= "3.7" and python_version < "3.11"
 oandapyv20==0.6.3
 oauthlib==3.1.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
@@ -154,16 +154,16 @@ pmdarima==1.8.4; python_version >= "3.6"
 praw==7.5.0; python_version >= "3.6" and python_version < "4.0"
 prawcore==2.3.0; python_version >= "3.6" and python_version < "4.0"
 pre-commit==2.16.0; python_full_version >= "3.6.1"
-prometheus-client==0.12.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+prometheus-client==0.12.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 prompt-toolkit==3.0.24; python_full_version >= "3.6.2"
-protobuf==3.19.1; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and python_version >= "3.5"
+protobuf==3.19.3; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and python_version >= "3.5"
 psaw==0.0.12; python_version >= "3"
 ptyprocess==0.7.0; os_name != "nt" and python_version >= "3.7" and sys_platform != "win32"
-py==1.11.0; python_full_version >= "3.6.1" and python_version >= "3.7" and implementation_name == "pypy"
+py==1.11.0; python_full_version >= "3.7.0" and python_version >= "3.7" and implementation_name == "pypy"
 pyally==1.1.2
 pycodestyle==2.7.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pycoingecko==2.2.0
-pycparser==2.21; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.6.1"
+pycparser==2.21; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 pyex==0.5.0
 pyflakes==2.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pygments==2.11.2; python_version >= "3.5"
@@ -178,7 +178,12 @@ pyotp==2.6.0; python_version >= "3"
 pyparsing==3.0.6; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.7"
 pyportfolioopt==1.5.1; python_full_version >= "3.6.1" and python_full_version < "4.0.0"
 pyprind==2.11.3; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
-pyrsistent==0.18.0; python_version >= "3.6"
+pyqt5-qt5==5.15.2; python_version >= "3.6"
+pyqt5-sip==12.9.0; python_version >= "3.6"
+pyqt5==5.15.6; python_version >= "3.6"
+pyqtwebengine-qt5==5.15.2; python_version >= "3.6"
+pyqtwebengine==5.15.5; python_version >= "3.6"
+pyrsistent==0.18.1; python_version >= "3.7"
 pytest-mock==3.6.1; python_version >= "3.6"
 pytest-recording==0.12.0; python_version >= "3.5"
 pytest==6.2.5; python_version >= "3.6"
@@ -190,10 +195,10 @@ pytrends==4.7.3
 pytz-deprecation-shim==0.1.0.post0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6")
 pyupgrade==2.31.0; python_full_version >= "3.6.1"
-pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.7" and python_full_version >= "3.6.1"
-pywinpty==1.1.6; os_name == "nt" and python_version >= "3.6"
+pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.7" and python_full_version >= "3.7.0"
+pywinpty==1.1.6; os_name == "nt" and python_version >= "3.7"
 pyyaml==6.0; python_version >= "3.6" and python_full_version >= "3.6.1"
-pyzmq==22.3.0; python_full_version >= "3.6.1" and python_version >= "3.7"
+pyzmq==22.3.0; python_full_version >= "3.7.0" and python_version >= "3.7"
 qdldl==0.1.5.post0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 qtconsole==5.2.2; python_version >= "3.6"
 qtpy==2.0.0; python_version >= "3.6"
@@ -208,15 +213,15 @@ robin-stocks==2.1.0; python_version >= "3"
 scikit-learn==1.0.2; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 screeninfo==0.6.7
-scs==3.0.1; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
+scs==3.1.0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 seaborn==0.11.2; python_version >= "3.6"
 selenium==3.141.0
-send2trash==1.8.0; python_version >= "3.6"
+send2trash==1.8.0; python_version >= "3.7"
 sentiment-investor==2.1.0; python_version >= "3.8" and python_version < "4.0"
 setuptools-scm==6.3.2; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.7"
 six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7")
 smmap==5.0.0; python_version >= "3.7"
-sniffio==1.2.0; python_full_version >= "3.6.2" and python_version >= "3.6"
+sniffio==1.2.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 snowballstemmer==2.2.0; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.6"
 socketio-client-nexus==0.7.6
 soupsieve==2.3.1; python_version >= "3.6" and python_full_version > "3.0.0"
@@ -234,8 +239,7 @@ stevedore==3.5.0; python_version >= "3.6"
 tabulate==0.8.9
 temporal-cache==0.1.4
 tenacity==8.0.1; python_version >= "3.6"
-termcolor==1.1.0
-terminado==0.12.1; python_version >= "3.6"
+terminado==0.12.1; python_version >= "3.7"
 testpath==0.5.0; python_version >= "3.7"
 textwrap3==0.9.2; python_version >= "3.6"
 thepassiveinvestor==1.0.10
@@ -244,18 +248,17 @@ tokenize-rt==4.2.1; python_full_version >= "3.6.1"
 toml==0.10.2; python_full_version >= "3.6.2" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6")
 tomli==1.2.3; python_full_version >= "3.6.2" and python_version >= "3.7"
 toolz==0.11.2; python_version >= "3.7" and python_full_version >= "3.7.0"
-tornado==6.1; python_full_version >= "3.6.1" and python_version >= "3.7"
+tornado==6.1; python_full_version >= "3.7.0" and python_version >= "3.7"
 tqdm==4.62.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 tradingview-ta==3.2.10; python_version >= "3.6"
-traitlets==5.1.1; python_full_version >= "3.6.1" and python_version >= "3.7"
-types-python-dateutil==2.8.5
+traitlets==5.1.1; python_full_version >= "3.7.0" and python_version >= "3.7"
+types-python-dateutil==2.8.6
 types-pytz==2021.3.4
 types-pyyaml==6.0.3
-types-requests==2.27.3
+types-requests==2.27.7
 types-setuptools==57.4.7
 types-tabulate==0.8.5
-types-termcolor==1.1.3
-types-urllib3==1.26.1
+types-urllib3==1.26.7
 typing-extensions==4.0.1; python_version < "3.10" and python_full_version >= "3.6.2" and python_version >= "3.6"
 tzdata==2021.5; platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 tzlocal==4.1; python_version >= "3.6"
@@ -269,12 +272,12 @@ valinvest==0.0.2; python_version >= "3.6"
 vcrpy==4.1.1; python_version >= "3.5"
 virtualenv==20.13.0; python_full_version >= "3.6.1"
 voila==0.3.0; python_version >= "3.6"
-wcwidth==0.2.5; python_version >= "3.7" and python_full_version >= "3.6.2"
+wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.7"
 webencodings==0.5.1; python_version >= "3.7"
 websocket-client==1.2.3; python_version >= "3.8" and python_version < "4.0"
 websockets==9.1; python_full_version >= "3.6.1" and python_version >= "3.6"
 widgetsnbextension==3.5.2
 wrapt==1.13.3; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5")
 yarl==1.7.2; python_version >= "3.6"
-yfinance==0.1.68
+yfinance==0.1.69
 zope.interface==5.4.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"

--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -14,6 +14,7 @@ import pandas as pd
 from rich.table import Table
 import iso8601
 
+import plotly.offline
 import matplotlib
 import matplotlib.pyplot as plt
 from holidays import US as us_holidays
@@ -23,6 +24,9 @@ from pandas.plotting import register_matplotlib_converters
 import pandas.io.formats.format
 import requests
 from screeninfo import get_monitors
+from PyQt5.QtCore import QUrl
+from PyQt5.QtWebEngineWidgets import QWebEngineView
+from PyQt5.QtWidgets import QApplication
 
 from gamestonk_terminal.rich_config import console
 from gamestonk_terminal import feature_flags as gtff
@@ -1031,3 +1035,23 @@ def excel_columns() -> List[str]:
         + [f"{x}{y}{z}" for x in letters for y in letters for z in letters]
     )
     return opts
+
+
+def show_in_window(fig):
+    """
+    Show a plotly graph in a separate window
+
+    Parameters
+    ----------
+    fig :
+        The figure to show
+    """
+    file_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "name.html"))
+    plotly.offline.plot(fig, filename=file_path, auto_open=False)
+
+    app = QApplication(sys.argv)
+    web = QWebEngineView()
+
+    web.load(QUrl.fromLocalFile(file_path))
+    web.show()
+    sys.exit(app.exec_())

--- a/poetry.lock
+++ b/poetry.lock
@@ -2489,6 +2489,55 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "pyqt5"
+version = "5.15.6"
+description = "Python bindings for the Qt cross platform application toolkit"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+PyQt5-Qt5 = ">=5.15.2"
+PyQt5-sip = ">=12.8,<13"
+
+[[package]]
+name = "pyqt5-qt5"
+version = "5.15.2"
+description = "The subset of a Qt installation needed by PyQt5."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
+name = "pyqt5-sip"
+version = "12.9.0"
+description = "The sip module support for PyQt5"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[[package]]
+name = "pyqtwebengine"
+version = "5.15.5"
+description = "Python bindings for the Qt WebEngine framework"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+PyQt5 = ">=5.15.4"
+PyQt5-sip = ">=12.8,<13"
+PyQtWebEngine-Qt5 = ">=5.15.2"
+
+[[package]]
+name = "pyqtwebengine-qt5"
+version = "5.15.2"
+description = "The subset of a Qt installation needed by PyQtWebEngine."
+category = "main"
+optional = false
+python-versions = "*"
+
+[[package]]
 name = "pyrsistent"
 version = "0.18.1"
 description = "Persistent/Functional/Immutable data structures"
@@ -3782,7 +3831,7 @@ prediction = ["tensorflow"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.10"
-content-hash = "3b4f31f2583aeff320c24589bd1544bc630889520f4243a5eb28ed19086f0b3a"
+content-hash = "15a544b93d8b2e6308c8363064d0cf963b50f4afdc31ab5374c3196e39459a78"
 
 [metadata.files]
 absl-py = [
@@ -5445,6 +5494,55 @@ pyportfolioopt = [
 pyprind = [
     {file = "PyPrind-2.11.3-py2.py3-none-any.whl", hash = "sha256:cc8edb66aabb18f25f7a3cce65312b3bc64b49992ddc93ba4cf511e5e25c1be3"},
     {file = "PyPrind-2.11.3.tar.gz", hash = "sha256:e37dcab6e1a9c8e0a7f0fce65fde7a79e2deda1c75aa015910a49e2137b54cbf"},
+]
+pyqt5 = [
+    {file = "PyQt5-5.15.6-cp36-abi3-macosx_10_13_x86_64.whl", hash = "sha256:33ced1c876f6a26e7899615a5a4efef2167c263488837c7beed023a64cebd051"},
+    {file = "PyQt5-5.15.6-cp36-abi3-manylinux1_x86_64.whl", hash = "sha256:9d6efad0377aa78bf081a20ac752ce86096ded18f04c592d98f5b92dc879ad0a"},
+    {file = "PyQt5-5.15.6-cp36-abi3-win32.whl", hash = "sha256:9d2dcdaf82263ae56023410a7af15d1fd746c8e361733a7d0d1bd1f004ec2793"},
+    {file = "PyQt5-5.15.6-cp36-abi3-win_amd64.whl", hash = "sha256:f411ecda52e488e1d3c5cce7563e1b2ca9cf0b7531e3c25b03d9a7e56e07e7fc"},
+    {file = "PyQt5-5.15.6.tar.gz", hash = "sha256:80343bcab95ffba619f2ed2467fd828ffeb0a251ad7225be5fc06dcc333af452"},
+]
+pyqt5-qt5 = [
+    {file = "PyQt5_Qt5-5.15.2-py3-none-macosx_10_13_intel.whl", hash = "sha256:76980cd3d7ae87e3c7a33bfebfaee84448fd650bad6840471d6cae199b56e154"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:1988f364ec8caf87a6ee5d5a3a5210d57539988bf8e84714c7d60972692e2f4a"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-win32.whl", hash = "sha256:9cc7a768b1921f4b982ebc00a318ccb38578e44e45316c7a4a850e953e1dd327"},
+    {file = "PyQt5_Qt5-5.15.2-py3-none-win_amd64.whl", hash = "sha256:750b78e4dba6bdf1607febedc08738e318ea09e9b10aea9ff0d73073f11f6962"},
+]
+pyqt5-sip = [
+    {file = "PyQt5_sip-12.9.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:6d5bca2fc222d58e8093ee8a81a6e3437067bb22bc3f86d06ec8be721e15e90a"},
+    {file = "PyQt5_sip-12.9.0-cp310-cp310-manylinux1_x86_64.whl", hash = "sha256:d59af63120d1475b2bf94fe8062610720a9be1e8940ea146c7f42bb449d49067"},
+    {file = "PyQt5_sip-12.9.0-cp310-cp310-win32.whl", hash = "sha256:0fc9aefacf502696710b36cdc9fa2a61487f55ee883dbcf2c2a6477e261546f7"},
+    {file = "PyQt5_sip-12.9.0-cp310-cp310-win_amd64.whl", hash = "sha256:485972daff2fb0311013f471998f8ec8262ea381bded244f9d14edaad5f54271"},
+    {file = "PyQt5_sip-12.9.0-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:d85002238b5180bce4b245c13d6face848faa1a7a9e5c6e292025004f2fd619a"},
+    {file = "PyQt5_sip-12.9.0-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:83c3220b1ca36eb8623ba2eb3766637b19eb0ce9f42336ad8253656d32750c0a"},
+    {file = "PyQt5_sip-12.9.0-cp36-cp36m-win32.whl", hash = "sha256:d8b2bdff7bbf45bc975c113a03b14fd669dc0c73e1327f02706666a7dd51a197"},
+    {file = "PyQt5_sip-12.9.0-cp36-cp36m-win_amd64.whl", hash = "sha256:69a3ad4259172e2b1aa9060de211efac39ddd734a517b1924d9c6c0cc4f55f96"},
+    {file = "PyQt5_sip-12.9.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:42274a501ab4806d2c31659170db14c282b8313d2255458064666d9e70d96206"},
+    {file = "PyQt5_sip-12.9.0-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:6a8701892a01a5a2a4720872361197cc80fdd5f49c8482d488ddf38c9c84f055"},
+    {file = "PyQt5_sip-12.9.0-cp37-cp37m-win32.whl", hash = "sha256:ac57d796c78117eb39edd1d1d1aea90354651efac9d3590aac67fa4983f99f1f"},
+    {file = "PyQt5_sip-12.9.0-cp37-cp37m-win_amd64.whl", hash = "sha256:4347bd81d30c8e3181e553b3734f91658cfbdd8f1a19f254777f906870974e6d"},
+    {file = "PyQt5_sip-12.9.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c446971c360a0a1030282a69375a08c78e8a61d568bfd6dab3dcc5cf8817f644"},
+    {file = "PyQt5_sip-12.9.0-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:fc43f2d7c438517ee33e929e8ae77132749c15909afab6aeece5fcf4147ffdb5"},
+    {file = "PyQt5_sip-12.9.0-cp38-cp38-win32.whl", hash = "sha256:055581c6fed44ba4302b70eeb82e979ff70400037358908f251cd85cbb3dbd93"},
+    {file = "PyQt5_sip-12.9.0-cp38-cp38-win_amd64.whl", hash = "sha256:c5216403d4d8d857ec4a61f631d3945e44fa248aa2415e9ee9369ab7c8a4d0c7"},
+    {file = "PyQt5_sip-12.9.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a25b9843c7da6a1608f310879c38e6434331aab1dc2fe6cb65c14f1ecf33780e"},
+    {file = "PyQt5_sip-12.9.0-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:dd05c768c2b55ffe56a9d49ce6cc77cdf3d53dbfad935258a9e347cbfd9a5850"},
+    {file = "PyQt5_sip-12.9.0-cp39-cp39-win32.whl", hash = "sha256:4f8e05fe01d54275877c59018d8e82dcdd0bc5696053a8b830eecea3ce806121"},
+    {file = "PyQt5_sip-12.9.0-cp39-cp39-win_amd64.whl", hash = "sha256:b09f4cd36a4831229fb77c424d89635fa937d97765ec90685e2f257e56a2685a"},
+    {file = "PyQt5_sip-12.9.0.tar.gz", hash = "sha256:d3e4489d7c2b0ece9d203ae66e573939f7f60d4d29e089c9f11daa17cfeaae32"},
+]
+pyqtwebengine = [
+    {file = "PyQtWebEngine-5.15.5-cp36-abi3-macosx_10_13_x86_64.whl", hash = "sha256:5c77f71d88d871bc7400c68ef6433fadc5bd57b86d1a9c4d8094cea42f3607f1"},
+    {file = "PyQtWebEngine-5.15.5-cp36-abi3-manylinux1_x86_64.whl", hash = "sha256:782aeee6bc8699bc029fe5c169a045c2bc9533d781cf3f5e9fb424b85a204e68"},
+    {file = "PyQtWebEngine-5.15.5-cp36-abi3-win32.whl", hash = "sha256:b827ad7ba0a65d5cd176797478f0ec8f599df6746b06c548649ff5674482a022"},
+    {file = "PyQtWebEngine-5.15.5-cp36-abi3-win_amd64.whl", hash = "sha256:30cebf455406990d5a0b859eac261ba6b45c32ce18956271733e0e96dbdca9b7"},
+    {file = "PyQtWebEngine-5.15.5.tar.gz", hash = "sha256:ab47608dccf2b5e4b950d5a3cc704b17711af035024d07a9b71ad29fc103b941"},
+]
+pyqtwebengine-qt5 = [
+    {file = "PyQtWebEngine_Qt5-5.15.2-py3-none-macosx_10_13_intel.whl", hash = "sha256:bc7b1fd1f4f8138d59b0b0245d601fb2c5c0aa1e1e7e853b713e52a3165d147e"},
+    {file = "PyQtWebEngine_Qt5-5.15.2-py3-none-manylinux2014_x86_64.whl", hash = "sha256:ec2acb1780c0124ef060c310e00ca701f388d8b6c35bba9127f7a6f0dc536f77"},
+    {file = "PyQtWebEngine_Qt5-5.15.2-py3-none-win32.whl", hash = "sha256:9e80b408d8de09d4e708d5d84c3ceaf3603292ff8f5e566ae44bb0320fa59c33"},
+    {file = "PyQtWebEngine_Qt5-5.15.2-py3-none-win_amd64.whl", hash = "sha256:24231f19e1595018779977de6722b5c69f3d03f34a5f7574ff21cd1e764ef76d"},
 ]
 pyrsistent = [
     {file = "pyrsistent-0.18.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,6 +83,8 @@ discord-components = {version = "^2.1.2", optional = true}
 pyimgur = {version = "^0.6.0", optional = true}
 python-dotenv = {version = "^0.19.2", optional = true}
 Pygments = "2.11.2"
+PyQt5 = "^5.15.6"
+PyQtWebEngine = "^5.15.5"
 
 
 

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -3,16 +3,16 @@ aiohttp==3.7.4.post0; python_version >= "3.6"
 alabaster==0.7.12; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.6"
 alpha-vantage==2.3.1
 ansiwrap==0.8.4; python_version >= "3.6"
-anyio==3.4.0; python_full_version >= "3.6.2" and python_version >= "3.6"
+anyio==3.5.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 appdirs==1.4.4; python_full_version >= "3.6.2" and python_version >= "3.6"
 appnope==0.1.2; platform_system == "Darwin" and python_version >= "3.7" and sys_platform == "darwin"
-argon2-cffi-bindings==21.2.0; python_version >= "3.6"
-argon2-cffi==21.3.0; python_version >= "3.6"
-astroid==2.9.2; python_full_version >= "3.6.2"
+argon2-cffi-bindings==21.2.0; python_version >= "3.7"
+argon2-cffi==21.3.0; python_version >= "3.7"
+astroid==2.9.3; python_full_version >= "3.6.2"
 astunparse==1.6.3
 async-timeout==3.0.1; python_full_version >= "3.5.3" and python_version >= "3.6"
 atomicwrites==1.4.0; python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.4.0"
-attrs==21.4.0; python_full_version >= "3.6.1" and python_version >= "3.6" and python_version < "4.0"
+attrs==21.4.0; python_full_version >= "3.7.0" and python_version >= "3.6" and python_version < "4.0"
 babel==2.9.1; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6")
 backcall==0.2.0; python_version >= "3.7"
 backports.zoneinfo==0.2.1; python_version < "3.9" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
@@ -25,7 +25,7 @@ bs4==0.0.1
 bt==0.2.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 cachetools==4.2.4; python_version >= "3.5" and python_version < "4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 certifi==2021.10.8; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0") and (python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3")
-cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.6.1"
+cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 cfgv==3.3.1; python_full_version >= "3.6.1"
 chardet==4.0.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
 charset-normalizer==2.0.10; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0") and (python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3")
@@ -52,7 +52,7 @@ distlib==0.3.4; python_full_version >= "3.6.1"
 dnspython==2.1.0; python_version >= "3.6"
 docutils==0.16; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6")
 ecos==2.0.10; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
-entrypoints==0.3; python_full_version >= "3.6.1" and python_version >= "3.7"
+entrypoints==0.3; python_full_version >= "3.7.0" and python_version >= "3.7"
 et-xmlfile==1.1.0; python_version >= "3.6"
 exchange-calendars==3.5; python_version >= "3.7" and python_full_version >= "3.7.0"
 fear-greed-index==0.1.3; python_full_version >= "3.6.8" and python_full_version < "4.0.0"
@@ -71,7 +71,7 @@ fundamentalanalysis==0.2.12
 future==0.18.2; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 gast==0.4.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 gitdb==4.0.9; python_version >= "3.7"
-gitpython==3.1.25; python_version >= "3.7"
+gitpython==3.1.26; python_version >= "3.7"
 google-auth-oauthlib==0.4.6; python_version >= "3.6"
 google-auth==2.3.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 google-pasta==0.2.0
@@ -79,16 +79,16 @@ grpcio==1.43.0; python_full_version >= "3.7.1" and python_full_version < "4.0.0"
 h5py==3.6.0; python_version >= "3.7"
 hijri-converter==2.2.2; python_version >= "3.6"
 holidays==0.11.3.1; python_version >= "3.6"
-identify==2.4.2; python_full_version >= "3.6.1"
-idna==3.3; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0") and (python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3")
+identify==2.4.4; python_full_version >= "3.6.1"
+idna==3.3; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0") and (python_version >= "3" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3")
 imagesize==1.3.0; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.6"
 importlib-metadata==4.10.0; python_version < "3.10" and python_version >= "3.7"
 inflection==0.5.1; python_version >= "3.6"
 iniconfig==1.1.1; python_version >= "3.6"
 investpy==1.0.7; python_version >= "3"
-ipykernel==6.6.1; python_version >= "3.7"
+ipykernel==6.7.0; python_version >= "3.7"
 ipympl==0.8.5
-ipython-genutils==0.2.0; python_full_version >= "3.6.1" and python_version >= "3.6"
+ipython-genutils==0.2.0; python_full_version >= "3.7.0" and python_version >= "3.7"
 ipython==7.31.0; python_version >= "3.7"
 ipywidgets==7.6.5
 iso8601==0.1.16
@@ -98,15 +98,15 @@ jinja2==3.0.3; python_full_version >= "3.6.8" and python_full_version < "4.0.0" 
 joblib==1.1.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 json5==0.9.6; python_version >= "3.6"
 jsonschema==3.2.0
-jupyter-client==7.1.0; python_full_version >= "3.6.1" and python_version >= "3.7"
+jupyter-client==7.1.1; python_full_version >= "3.7.0" and python_version >= "3.7"
 jupyter-console==6.4.0; python_version >= "3.6"
-jupyter-core==4.9.1; python_full_version >= "3.6.1" and python_version >= "3.7"
-jupyter-server==1.13.1; python_version >= "3.6"
+jupyter-core==4.9.1; python_full_version >= "3.7.0" and python_version >= "3.7"
+jupyter-server==1.13.3; python_version >= "3.7"
 jupyter==1.0.0
 jupyterlab-pygments==0.1.2; python_version >= "3.7"
 jupyterlab-server==2.10.3; python_version >= "3.6"
 jupyterlab-widgets==1.0.2; python_version >= "3.6"
-jupyterlab==3.2.6; python_version >= "3.6"
+jupyterlab==3.2.8; python_version >= "3.6"
 keras-preprocessing==1.1.2
 keras==2.7.0
 kiwisolver==1.3.2; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.7"
@@ -131,13 +131,13 @@ multitasking==0.0.10
 mypy-extensions==0.4.3; python_full_version >= "3.6.2" and python_version >= "3.6"
 mypy==0.930; python_version >= "3.6"
 myst-parser==0.15.2; python_version >= "3.6"
-nbclassic==0.3.4; python_version >= "3.6"
-nbclient==0.5.9; python_full_version >= "3.6.1" and python_version >= "3.7"
+nbclassic==0.3.5; python_version >= "3.6"
+nbclient==0.5.10; python_full_version >= "3.7.0" and python_version >= "3.7"
 nbconvert==6.4.0; python_version >= "3.7"
-nbformat==5.1.3; python_full_version >= "3.6.1" and python_version >= "3.7"
-nest-asyncio==1.5.4; python_full_version >= "3.6.1" and python_version >= "3.7"
+nbformat==5.1.3; python_full_version >= "3.7.0" and python_version >= "3.7"
+nest-asyncio==1.5.4; python_full_version >= "3.7.0" and python_version >= "3.7"
 nodeenv==1.6.0; python_full_version >= "3.6.1"
-notebook==6.4.6; python_version >= "3.6"
+notebook==6.4.7; python_version >= "3.6"
 numpy==1.21.2; python_version >= "3.7" and python_version < "3.11"
 oandapyv20==0.6.3
 oauthlib==3.1.1; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
@@ -166,18 +166,18 @@ pmdarima==1.8.4; python_version >= "3.6"
 praw==7.5.0; python_version >= "3.6" and python_version < "4.0"
 prawcore==2.3.0; python_version >= "3.6" and python_version < "4.0"
 pre-commit==2.16.0; python_full_version >= "3.6.1"
-prometheus-client==0.12.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+prometheus-client==0.12.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 prompt-toolkit==3.0.24; python_full_version >= "3.6.2"
-protobuf==3.19.1; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and python_version >= "3.6"
+protobuf==3.19.3; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 psaw==0.0.12; python_version >= "3"
 ptyprocess==0.7.0; os_name != "nt" and python_version >= "3.7" and sys_platform != "win32"
-py==1.11.0; python_full_version >= "3.6.1" and python_version >= "3.7" and implementation_name == "pypy"
+py==1.11.0; python_full_version >= "3.7.0" and python_version >= "3.7" and implementation_name == "pypy"
 pyally==1.1.2
 pyasn1-modules==0.2.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 pyasn1==0.4.8; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") or python_full_version >= "3.6.0" and python_version >= "3.6" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 pycodestyle==2.7.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pycoingecko==2.2.0
-pycparser==2.21; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.6.1"
+pycparser==2.21; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 pyex==0.5.0
 pyflakes==2.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pygments==2.11.2; python_version >= "3.5"
@@ -191,7 +191,12 @@ pyotp==2.6.0; python_version >= "3"
 pyparsing==3.0.6; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.7"
 pyportfolioopt==1.5.1; python_full_version >= "3.6.1" and python_full_version < "4.0.0"
 pyprind==2.11.3; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
-pyrsistent==0.18.0; python_version >= "3.6"
+pyqt5-qt5==5.15.2; python_version >= "3.6"
+pyqt5-sip==12.9.0; python_version >= "3.6"
+pyqt5==5.15.6; python_version >= "3.6"
+pyqtwebengine-qt5==5.15.2; python_version >= "3.6"
+pyqtwebengine==5.15.5; python_version >= "3.6"
+pyrsistent==0.18.1; python_version >= "3.7"
 pytest-mock==3.6.1; python_version >= "3.6"
 pytest-recording==0.12.0; python_version >= "3.5"
 pytest==6.2.5; python_version >= "3.6"
@@ -203,10 +208,10 @@ pytrends==4.7.3
 pytz-deprecation-shim==0.1.0.post0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6")
 pyupgrade==2.31.0; python_full_version >= "3.6.1"
-pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.7" and python_full_version >= "3.6.1"
-pywinpty==1.1.6; os_name == "nt" and python_version >= "3.6"
+pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.7" and python_full_version >= "3.7.0"
+pywinpty==1.1.6; os_name == "nt" and python_version >= "3.7"
 pyyaml==6.0; python_version >= "3.6" and python_full_version >= "3.6.1"
-pyzmq==22.3.0; python_full_version >= "3.6.1" and python_version >= "3.7"
+pyzmq==22.3.0; python_full_version >= "3.7.0" and python_version >= "3.7"
 qdldl==0.1.5.post0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 qtconsole==5.2.2; python_version >= "3.6"
 qtpy==2.0.0; python_version >= "3.6"
@@ -222,15 +227,15 @@ rsa==4.8; python_version >= "3.6" and python_version < "4" and (python_version >
 scikit-learn==1.0.2; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 screeninfo==0.6.7
-scs==3.0.1; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
+scs==3.1.0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 seaborn==0.11.2; python_version >= "3.6"
 selenium==3.141.0
-send2trash==1.8.0; python_version >= "3.6"
+send2trash==1.8.0; python_version >= "3.7"
 sentiment-investor==2.1.0; python_version >= "3.8" and python_version < "4.0"
 setuptools-scm==6.3.2; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.7"
 six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 smmap==5.0.0; python_version >= "3.7"
-sniffio==1.2.0; python_full_version >= "3.6.2" and python_version >= "3.6"
+sniffio==1.2.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 snowballstemmer==2.2.0; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.6"
 socketio-client-nexus==0.7.6
 soupsieve==2.3.1; python_version >= "3.6" and python_full_version > "3.0.0"
@@ -255,7 +260,7 @@ tensorflow-estimator==2.7.0
 tensorflow-io-gcs-filesystem==0.23.1; python_version >= "3.7" and python_version < "3.11"
 tensorflow==2.7.0
 termcolor==1.1.0
-terminado==0.12.1; python_version >= "3.6"
+terminado==0.12.1; python_version >= "3.7"
 testpath==0.5.0; python_version >= "3.7"
 textwrap3==0.9.2; python_version >= "3.6"
 thepassiveinvestor==1.0.10
@@ -264,17 +269,17 @@ tokenize-rt==4.2.1; python_full_version >= "3.6.1"
 toml==0.10.2; python_full_version >= "3.6.2" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6")
 tomli==1.2.3; python_full_version >= "3.6.2" and python_version >= "3.7"
 toolz==0.11.2; python_version >= "3.7" and python_full_version >= "3.7.0"
-tornado==6.1; python_full_version >= "3.6.1" and python_version >= "3.7"
+tornado==6.1; python_full_version >= "3.7.0" and python_version >= "3.7"
 tqdm==4.62.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 tradingview-ta==3.2.10; python_version >= "3.6"
-traitlets==5.1.1; python_full_version >= "3.6.1" and python_version >= "3.7"
-types-python-dateutil==2.8.5
+traitlets==5.1.1; python_full_version >= "3.7.0" and python_version >= "3.7"
+types-python-dateutil==2.8.6
 types-pytz==2021.3.4
 types-pyyaml==6.0.3
-types-requests==2.27.3
+types-requests==2.27.7
 types-setuptools==57.4.7
 types-tabulate==0.8.5
-types-urllib3==1.26.1
+types-urllib3==1.26.7
 typing-extensions==4.0.1; python_version < "3.10" and python_full_version >= "3.6.2" and python_version >= "3.6"
 tzdata==2021.5; platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 tzlocal==4.1; python_version >= "3.6"
@@ -296,6 +301,6 @@ werkzeug==2.0.2; python_version >= "3.6"
 widgetsnbextension==3.5.2
 wrapt==1.13.3; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5")
 yarl==1.7.2; python_version >= "3.6"
-yfinance==0.1.68
+yfinance==0.1.69
 zipp==3.7.0; python_version < "3.10" and python_version >= "3.7"
 zope.interface==5.4.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"

--- a/requirements.txt
+++ b/requirements.txt
@@ -145,6 +145,11 @@ pyotp==2.6.0; python_version >= "3"
 pyparsing==3.0.6; python_full_version >= "3.6.8" and python_full_version < "4.0.0" and python_version >= "3.7"
 pyportfolioopt==1.5.1; python_full_version >= "3.6.1" and python_full_version < "4.0.0"
 pyprind==2.11.3; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+pyqt5-qt5==5.15.2; python_version >= "3.6"
+pyqt5-sip==12.9.0; python_version >= "3.6"
+pyqt5==5.15.6; python_version >= "3.6"
+pyqtwebengine-qt5==5.15.2; python_version >= "3.6"
+pyqtwebengine==5.15.5; python_version >= "3.6"
 pyrsistent==0.18.1; python_version >= "3.7"
 python-binance==1.0.15
 python-coinmarketcap==0.2


### PR DESCRIPTION
# Description

Allows users to view interactive plotly graphs in a separate window (like Matplotlib). Based on [this](https://stackoverflow.com/questions/53570384/plotly-how-to-make-a-standalone-plot-in-a-window) article.


# How has this been tested?

I added the function from the url above and it worked flawlessly.


# Checklist:

- [ ] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
