### PR TITLE
Added Open MIT options course

### DIFF
--- a/gamestonk_terminal/stocks/README.md
+++ b/gamestonk_terminal/stocks/README.md
@@ -2,3 +2,4 @@
 
 * Compilation of free knowledge and educational resources : <https://econiverse.github.io>
 * Hedge fund letters or reports : <https://miltonfmr.com/hedge-fund-letters/>
+* Open MIT Open Online course on equity options: https://ocw.mit.edu/courses/sloan-school-of-management/15-401-finance-theory-i-fall-2008/video-lectures-and-slides/options/


### PR DESCRIPTION
This adds a link to the stocks/resources for an Open MIT course on equity options. 