### PR TITLE
Improved Debugging

### DIFF
--- a/gamestonk_terminal/decorators.py
+++ b/gamestonk_terminal/decorators.py
@@ -4,6 +4,8 @@ import functools
 import logging
 import os
 
+from gamestonk_terminal.rich_config import console
+
 logger = logging.getLogger(__name__)
 
 
@@ -23,6 +25,7 @@ def try_except(f):
         try:
             return f(*args, **kwargs)
         except Exception as e:
+            console.print(f"[red]Error: {e}[/red]")
             logger.exception("%s", type(e).__name__)
             return []
 

--- a/terminal.py
+++ b/terminal.py
@@ -10,7 +10,6 @@ from typing import List
 import pytz
 
 from prompt_toolkit.completion import NestedCompleter
-
 from gamestonk_terminal.rich_config import console
 from gamestonk_terminal.parent_classes import BaseController
 from gamestonk_terminal import feature_flags as gtff
@@ -321,8 +320,6 @@ if __name__ == "__main__":
         if "--debug" in sys.argv:
             os.environ["DEBUG_MODE"] = "true"
             sys.argv.remove("--debug")
-        else:
-            os.environ["DEBUG_MODE"] = "false"
         if len(sys.argv) > 1 and ".gst" in sys.argv[1]:
             if os.path.isfile(sys.argv[1]):
                 with open(sys.argv[1]) as fp:
@@ -336,5 +333,4 @@ if __name__ == "__main__":
         else:
             terminal(sys.argv[1:])
     else:
-        os.environ["DEBUG_MODE"] = "false"
         terminal()


### PR DESCRIPTION
# Description

I removed terminal.py setting the DEBUG_MODE to "false" if --debug is not included. This allows DEBUG_MODE to be sent as an environment variable. ALSO, I added a print out if there is an error. I think it is important for a user to know there was an error, and personally with the current setup I am often left wondering if there was an error or if the function just lacks output.


# How has this been tested?

Ran the terminal with and without --debug mode for functions that cause errors.


# Checklist:

- [x] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
