### PR TITLE
Fixed intraday tickers

### DIFF
--- a/gamestonk_terminal/jupyter/dashboards/stocks.ipynb
+++ b/gamestonk_terminal/jupyter/dashboards/stocks.ipynb
@@ -99,8 +99,9 @@
     "                        tickers, period=\"max\", interval=interval, progress=False\n",
     "                    )\n",
     "                else:\n",
+    "                    end_date = end + timedelta(days=1)\n",
     "                    self.df = yf.download(\n",
-    "                        tickers, start=start, end=end, interval=interval, progress=False\n",
+    "                        tickers, start=start, end=end_date, interval=interval, progress=False\n",
     "                    )\n",
     "                self.last_tickers = tickers\n",
     "                self.last_interval = interval\n",
@@ -209,9 +210,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": ""
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
# Description

Fixes an issue that does not show one day intraday information on the stocks dashboard.


# How has this been tested?

Fixed the ability to see the information.


# Checklist:

- [x] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
