### PR TITLE
Fixed quote bug

### DIFF
--- a/gamestonk_terminal/stocks/stocks_helper.py
+++ b/gamestonk_terminal/stocks/stocks_helper.py
@@ -596,7 +596,7 @@ def quote(other_args: List[str], s_ticker: str):
 
         quote_data = transpose(quote_df)
 
-        print_rich_table(quote_data, title="Ticker Quote")
+        print_rich_table(quote_data, title="Ticker Quote", show_index=True)
 
     except KeyError:
         console.print(f"Invalid stock ticker: {ns_parser.s_ticker}")


### PR DESCRIPTION
# Description

Added show_index to the stocks quote function.


# How has this been tested?

Ran pytest.

# Checklist:

- [x] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
