### PR TITLE
Added show_index

### DIFF
--- a/gamestonk_terminal/etf/stockanalysis_view.py
+++ b/gamestonk_terminal/etf/stockanalysis_view.py
@@ -56,6 +56,7 @@ def view_holdings(symbol: str, num_to_show: int, export: str):
         data[:num_to_show],
         headers=list(data.columns),
         title="ETF Holdings",
+        show_index=True,
     )
     console.print("")
 

--- a/gamestonk_terminal/stocks/fundamental_analysis/av_view.py
+++ b/gamestonk_terminal/stocks/fundamental_analysis/av_view.py
@@ -50,7 +50,7 @@ def display_key(ticker: str):
         console.print("No API calls left. Try me later", "\n")
         return
 
-    print_rich_table(df_key, headers=[], title="Ticker Key Metrics")
+    print_rich_table(df_key, headers=[], title="Ticker Key Metrics", show_index=True)
 
     console.print("")
 


### PR DESCRIPTION
# Description

Showed index for `stocks/fa/key` and `etf/holdings`. 


# How has this been tested?

Seeing the index shown.


# Checklist:

- [ ] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
