### PR TITLE
improve initial commands in terminal

### DIFF
--- a/terminal.py
+++ b/terminal.py
@@ -74,13 +74,7 @@ class TerminalController(BaseController):
         self.queue: List[str] = list()
 
         if jobs_cmds:
-            # close the eyes if the user forgets the initial `/`
-            jobs_cmds = [
-                job_cmd if job_cmd.startswith("/") else f"/{job_cmd}"
-                for job_cmd in jobs_cmds
-            ]
-
-            self.queue = self.switch(" ".join(jobs_cmds))
+            self.queue = " ".join(jobs_cmds).split("/")
 
         self.update_succcess = False
 
@@ -321,13 +315,19 @@ if __name__ == "__main__":
             if os.path.isfile(sys.argv[1]):
                 with open(sys.argv[1]) as fp:
                     simulate_argv = f"/{'/'.join([line.rstrip() for line in fp])}"
-                    terminal(simulate_argv.replace("//", "/home/").split())
+                    file_cmds = simulate_argv.replace("//", "/home/").split()
+                    # close the eyes if the user forgets the initial `/`
+                    if len(file_cmds) > 0:
+                        if file_cmds[0][0] != "/":
+                            file_cmds[0] = f"/{file_cmds[0]}"
+                    terminal(file_cmds)
             else:
                 console.print(
                     f"The file '{sys.argv[1]}' doesn't exist. Launching terminal without any configuration.\n"
                 )
                 terminal()
         else:
-            terminal(sys.argv[1:])
+            argv_cmds = list([" ".join(sys.argv[1:]).replace(" /", "/home/")])
+            terminal(argv_cmds)
     else:
         terminal()

--- a/terminal.py
+++ b/terminal.py
@@ -219,8 +219,7 @@ def terminal(jobs_cmds: List[str] = None):
 
     if not jobs_cmds:
         bootup()
-
-    t_controller.print_help()
+        t_controller.print_help()
 
     while ret_code:
         if gtff.ENABLE_QUICK_EXIT:


### PR DESCRIPTION
# Description

This should fix the .gst scripts + using multiple commands at start.

Additionally removed the initial menu being displayed since if the user uses an argument to start they don't want to see that menu because they know what they are doing.

# How has this been tested?

<img width="1146" alt="Screenshot 2022-02-02 at 00 22 52" src="https://user-images.githubusercontent.com/25267873/152073386-3522acb1-45fc-4f88-be38-ea9a304e4154.png">

<img width="1136" alt="Screenshot 2022-02-02 at 00 23 19" src="https://user-images.githubusercontent.com/25267873/152073418-8765141d-afdd-4b55-8195-474e47b1e0de.png">

