### PR TITLE
Brotli Wording

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -334,7 +334,7 @@ def brotli_check():
     installed_packages = pkg_resources.working_set
     for item in list(installed_packages):
         if "brotli" in str(item).lower():
-            pytest.exit("Uninstall brotli before running tests")
+            pytest.exit("Uninstall brotli and brotlipy before running tests")
 
 
 def disable_rich():


### PR DESCRIPTION
# Description

Improved Brotli warning wording to eliminate confusion.


# How has this been tested?

Ran tests.


# Checklist:

- [x] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
