### PR TITLE
Dev-dependencies : adding pytest-cov

### DIFF
--- a/discordbot/requirements.txt
+++ b/discordbot/requirements.txt
@@ -5,32 +5,33 @@ ansiwrap==0.8.4; python_version >= "3.6"
 anyio==3.5.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 appdirs==1.4.4; python_full_version >= "3.6.2" and python_version >= "3.8"
 appnope==0.1.2; platform_system == "Darwin" and python_version >= "3.8" and sys_platform == "darwin"
-argon2-cffi-bindings==21.2.0; python_version >= "3.7"
+argon2-cffi-bindings==21.2.0; python_version >= "3.6"
 argon2-cffi==21.3.0; python_version >= "3.7"
+ascii-magic==1.6; python_version >= "3.5"
 asgiref==3.5.0; python_version >= "3.7"
 astroid==2.9.3; python_full_version >= "3.6.2"
 asttokens==2.0.5; python_version >= "3.8"
-async-timeout==3.0.1; python_version >= "3.6" and python_full_version >= "3.8.0"
+async-timeout==3.0.1; python_full_version >= "3.5.3" and python_version >= "3.6"
 atomicwrites==1.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.4.0"
-attrs==21.4.0; python_full_version >= "3.8.0" and python_version >= "3.7" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.6" and python_version < "4.0" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7")
+attrs==21.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.7" and python_version < "4.0"
 babel==2.9.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 backcall==0.2.0; python_version >= "3.8"
 backports.zoneinfo==0.2.1; python_version < "3.9" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 bandit==1.7.2; python_version >= "3.7"
 beartype==0.7.1; python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0"
-beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.7"
+beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.5"
 black==21.7b0; python_full_version >= "3.6.2"
 bleach==4.1.0; python_version >= "3.7"
 bs4==0.0.1
 bt==0.2.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
-certifi==2021.10.8; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
-cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
+certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.6"
 cfgv==3.3.1; python_full_version >= "3.6.1"
-chardet==4.0.0; python_version >= "3.6" and python_full_version >= "3.8.0"
-charset-normalizer==2.0.11; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+chardet==4.0.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
+charset-normalizer==2.0.11; python_full_version >= "3.6.0" and python_version >= "3"
 click==8.0.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 codespell==2.1.0; python_version >= "3.5"
-colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows" and python_version >= "3.6") and platform_system == "Windows" and python_version >= "3.7" and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
+colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "2.7" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.6" and python_full_version >= "3.5.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
 commonmark==0.9.1; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 convertdate==2.4.0; python_version >= "3.7" and python_version < "4"
 coverage==6.3; python_version >= "3.7"
@@ -53,7 +54,7 @@ distlib==0.3.4; python_full_version >= "3.6.1"
 dnspython==2.2.0; python_version >= "3.6" and python_version < "4.0"
 docutils==0.16; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 ecos==2.0.10; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
-entrypoints==0.3; python_full_version >= "3.7.0" and python_version >= "3.7"
+entrypoints==0.3; python_full_version >= "3.6.1" and python_version >= "3.7"
 et-xmlfile==1.1.0; python_version >= "3.6"
 exchange-calendars==3.5.1; python_version >= "3.7" and python_full_version >= "3.7.0"
 executing==0.8.2; python_version >= "3.8"
@@ -78,26 +79,26 @@ h11==0.13.0; python_version >= "3.7"
 hijri-converter==2.2.2; python_version >= "3.6"
 holidays==0.11.3.1; python_version >= "3.6"
 identify==2.4.6; python_version >= "3.7" and python_full_version >= "3.6.1"
-idna==3.3; python_full_version >= "3.8.0" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+idna==3.3; python_full_version >= "3.6.2" and python_version >= "3.7"
 imagesize==1.3.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 inflection==0.5.1; python_version >= "3.6"
 iniconfig==1.1.1; python_version >= "3.7"
 investpy==1.0.8; python_version >= "3.7"
 ipykernel==6.7.0; python_version >= "3.7"
 ipympl==0.8.7
-ipython-genutils==0.2.0; python_full_version >= "3.7.0" and python_version >= "3.7"
+ipython-genutils==0.2.0; python_version >= "3.7"
 ipython==8.0.1; python_version >= "3.8"
 ipywidgets==7.6.5
 iso8601==0.1.16
 isort==5.10.1; python_full_version >= "3.6.2" and python_version < "4.0"
 jedi==0.18.1; python_version >= "3.8"
 jinja2==3.0.3; python_version >= "3.7"
-joblib==1.1.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
+joblib==1.1.0; python_version >= "3.7"
 json5==0.9.6; python_version >= "3.6"
 jsonschema==3.2.0
 jupyter-client==7.1.2; python_full_version >= "3.7.0" and python_version >= "3.7"
 jupyter-console==6.4.0; python_version >= "3.6"
-jupyter-core==4.9.1; python_full_version >= "3.7.0" and python_version >= "3.7"
+jupyter-core==4.9.1; python_full_version >= "3.6.1" and python_version >= "3.7"
 jupyter-server==1.13.4; python_version >= "3.7"
 jupyter==1.0.0
 jupyterlab-pygments==0.1.2; python_version >= "3.7"
@@ -111,7 +112,7 @@ lazy-object-proxy==1.7.1; python_version >= "3.6" and python_full_version >= "3.
 lxml==4.7.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 m2r2==0.2.8; python_version >= "3.7"
 markdown-it-py==1.1.0; python_version >= "3.6" and python_version < "4.0"
-markupsafe==2.0.1; python_version >= "3.7"
+markupsafe==2.0.1; python_version >= "3.6"
 matplotlib-inline==0.1.3; python_version >= "3.8"
 matplotlib==3.5.1; python_version >= "3.7"
 mccabe==0.6.1; python_full_version >= "3.6.2"
@@ -120,7 +121,7 @@ mistune==0.8.4; python_version >= "3.7"
 mock==4.0.3; python_version >= "3.6"
 more-itertools==8.12.0; python_version >= "3.6"
 mplfinance==0.12.8b6
-multidict==6.0.2; python_version >= "3.7" and python_full_version >= "3.8.0"
+multidict==6.0.2; python_version >= "3.7"
 multitasking==0.0.10
 mypy-extensions==0.4.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 mypy==0.930; python_version >= "3.6"
@@ -165,7 +166,7 @@ protobuf==3.19.4; python_full_version >= "3.7.1" and python_full_version < "4.0.
 psaw==0.0.12; python_version >= "3"
 ptyprocess==0.7.0; os_name != "nt" and python_version >= "3.8" and sys_platform != "win32"
 pure-eval==0.2.2; python_version >= "3.8"
-py==1.11.0; python_full_version >= "3.7.0" and python_version >= "3.7" and implementation_name == "pypy"
+py==1.11.0; python_version >= "3.7" and python_full_version < "3.0.0" and implementation_name == "pypy" or python_full_version >= "3.5.0" and python_version >= "3.7" and implementation_name == "pypy"
 pyally==1.1.2
 pycodestyle==2.7.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pycoingecko==2.2.0
@@ -187,21 +188,22 @@ pyparsing==3.0.7; python_version >= "3.7"
 pyportfolioopt==1.5.1; python_full_version >= "3.6.1" and python_full_version < "4.0.0"
 pyprind==2.11.3; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 pyrsistent==0.18.1; python_version >= "3.7"
+pytest-cov==3.0.0; python_version >= "3.6"
 pytest-mock==3.7.0; python_version >= "3.7"
 pytest-recording==0.12.0; python_version >= "3.5"
 pytest==6.2.5; python_version >= "3.6"
 python-binance==1.0.15
 python-coinmarketcap==0.2
-python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.8" and python_full_version < "4.0.0" and python_version < "4.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
+python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
 python-dotenv==0.19.2; python_version >= "3.5"
 pytrends==4.7.3
 pytz-deprecation-shim==0.1.0.post0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.8" and python_full_version < "4.0.0" and python_version < "4.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
+pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
 pyupgrade==2.31.0; python_full_version >= "3.6.1"
-pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.7" and python_full_version >= "3.7.0"
+pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.6"
 pywinpty==2.0.1; os_name == "nt" and python_version >= "3.7"
 pyyaml==6.0; python_version >= "3.7" and python_full_version >= "3.6.1"
-pyzmq==22.3.0; python_full_version >= "3.7.0" and python_version >= "3.7"
+pyzmq==22.3.0; python_full_version >= "3.6.1" and python_version >= "3.7"
 qdldl==0.1.5.post0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 qtconsole==5.2.2; python_version >= "3.6"
 qtpy==2.0.0; python_version >= "3.6"
@@ -214,7 +216,7 @@ requests==2.27.1; (python_version >= "2.7" and python_full_version < "3.0.0") or
 rich==10.16.2; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 robin-stocks==2.1.0; python_version >= "3"
 scikit-learn==1.0.2; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
-scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
 screeninfo==0.6.7
 scs==3.1.0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 seaborn==0.11.2; python_version >= "3.6"
@@ -222,7 +224,7 @@ selenium==3.141.0
 send2trash==1.8.0; python_version >= "3.7"
 sentiment-investor==2.1.0; python_version >= "3.8" and python_version < "4.0"
 setuptools-scm==6.4.2; python_version >= "3.7"
-six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.8" and python_full_version < "4.0.0" and python_version < "4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.3.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
+six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.3.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
 smmap==5.0.0; python_version >= "3.7"
 sniffio==1.2.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 snowballstemmer==2.2.0; python_version >= "3.7"
@@ -248,12 +250,12 @@ terminado==0.13.1; python_version >= "3.7"
 testpath==0.5.0; python_version >= "3.7"
 textwrap3==0.9.2; python_version >= "3.6"
 thepassiveinvestor==1.0.10
-threadpoolctl==3.0.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
+threadpoolctl==3.0.0; python_version >= "3.7"
 tokenize-rt==4.2.1; python_full_version >= "3.6.1"
 toml==0.10.2; python_full_version >= "3.6.2" and python_version >= "3.6" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7")
 tomli==1.2.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 toolz==0.11.2; python_version >= "3.7" and python_full_version >= "3.7.0"
-tornado==6.1; python_full_version >= "3.7.0" and python_version >= "3.7"
+tornado==6.1; python_full_version >= "3.6.1" and python_version >= "3.7"
 tqdm==4.62.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 tradingview-ta==3.2.10; python_version >= "3.6"
 traitlets==5.1.1; python_full_version >= "3.7.0" and python_version >= "3.8"
@@ -263,13 +265,13 @@ types-pyyaml==6.0.3
 types-requests==2.27.7
 types-setuptools==57.4.8
 types-urllib3==1.26.8
-typing-extensions==4.0.1; python_version < "3.10" and python_full_version >= "3.8.0" and python_version >= "3.6"
+typing-extensions==4.0.1; python_version < "3.10" and python_full_version >= "3.6.2" and python_version >= "3.6"
 tzdata==2021.5; platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 tzlocal==4.1; python_version >= "3.6"
 ujson==5.1.0; python_version >= "3.7"
 unidecode==1.3.2; python_version >= "3.7"
 update-checker==0.18.0; python_version >= "3.6" and python_version < "4.0"
-urllib3==1.26.8; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.8" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+urllib3==1.26.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 user-agent==0.1.10
 uvicorn==0.17.1; python_version >= "3.7"
 vadersentiment==3.3.2
@@ -277,12 +279,12 @@ valinvest==0.0.2; python_version >= "3.6"
 vcrpy==4.1.1; python_version >= "3.5"
 virtualenv==20.13.0; python_full_version >= "3.6.1"
 voila==0.3.1; python_version >= "3.7"
-wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.8"
+wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.6"
 webencodings==0.5.1; python_version >= "3.7"
 websocket-client==1.2.3; python_version >= "3.8" and python_version < "4.0"
 websockets==9.1; python_full_version >= "3.6.1" and python_version >= "3.7"
 widgetsnbextension==3.5.2
 wrapt==1.13.3; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5")
-yarl==1.7.2; python_version >= "3.6" and python_full_version >= "3.8.0"
+yarl==1.7.2; python_version >= "3.6"
 yfinance==0.1.70
 zope.interface==5.4.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -473,6 +473,9 @@ category = "dev"
 optional = false
 python-versions = ">=3.7"
 
+[package.dependencies]
+tomli = {version = "*", optional = true, markers = "extra == \"toml\""}
+
 [package.extras]
 toml = ["tomli"]
 
@@ -2641,6 +2644,21 @@ toml = "*"
 testing = ["argcomplete", "hypothesis (>=3.56)", "mock", "nose", "requests", "xmlschema"]
 
 [[package]]
+name = "pytest-cov"
+version = "3.0.0"
+description = "Pytest plugin for measuring coverage."
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+coverage = {version = ">=5.2.1", extras = ["toml"]}
+pytest = ">=4.6"
+
+[package.extras]
+testing = ["fields", "hunter", "process-tests", "six", "pytest-xdist", "virtualenv"]
+
+[[package]]
 name = "pytest-mock"
 version = "3.7.0"
 description = "Thin-wrapper around the mock package for easier use with pytest"
@@ -3945,7 +3963,7 @@ prediction = ["tensorflow"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.10"
-content-hash = "6442e535280a7bf7c0be6c6e857d0f5e6c7ee8765602c52b43b2c2190cad42d7"
+content-hash = "a17036617d87b60e3a7c60bd68f502ae6c1c6173e904bad87f9720940902fae7"
 
 [metadata.files]
 absl-py = [
@@ -5694,6 +5712,10 @@ pyrsistent = [
 pytest = [
     {file = "pytest-6.2.5-py3-none-any.whl", hash = "sha256:7310f8d27bc79ced999e760ca304d69f6ba6c6649c0b60fb0e04a4a77cacc134"},
     {file = "pytest-6.2.5.tar.gz", hash = "sha256:131b36680866a76e6781d13f101efb86cf674ebb9762eb70d3082b6f29889e89"},
+]
+pytest-cov = [
+    {file = "pytest-cov-3.0.0.tar.gz", hash = "sha256:e7f0f5b1617d2210a2cabc266dfe2f4c75a8d32fb89eafb7ad9d06f6d076d470"},
+    {file = "pytest_cov-3.0.0-py3-none-any.whl", hash = "sha256:578d5d15ac4a25e5f961c938b85a05b09fdaae9deef3bb6de9a6e766622ca7a6"},
 ]
 pytest-mock = [
     {file = "pytest-mock-3.7.0.tar.gz", hash = "sha256:5112bd92cc9f186ee96e1a92efc84969ea494939c3aead39c50f421c4cc69534"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ types-python-dateutil = "^2.8.3"
 types-setuptools = "^57.4.7"
 pre-commit = "^2.16.0"
 pandas-market-calendars = "^3.2"
+pytest-cov = "^3.0.0"
 
 [tool.poetry.extras]
 prediction = ["tensorflow"]

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -6,7 +6,7 @@ ansiwrap==0.8.4; python_version >= "3.6"
 anyio==3.5.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 appdirs==1.4.4; python_full_version >= "3.6.2" and python_version >= "3.8"
 appnope==0.1.2; platform_system == "Darwin" and python_version >= "3.8" and sys_platform == "darwin"
-argon2-cffi-bindings==21.2.0; python_version >= "3.7"
+argon2-cffi-bindings==21.2.0; python_version >= "3.6"
 argon2-cffi==21.3.0; python_version >= "3.7"
 ascii-magic==1.6; python_version >= "3.5"
 astroid==2.9.3; python_full_version >= "3.6.2"
@@ -14,26 +14,26 @@ asttokens==2.0.5; python_version >= "3.8"
 astunparse==1.6.3
 async-timeout==3.0.1; python_full_version >= "3.5.3" and python_version >= "3.6"
 atomicwrites==1.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.4.0"
-attrs==21.4.0; python_full_version >= "3.7.0" and python_version >= "3.7" and python_version < "4.0"
+attrs==21.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.7" and python_version < "4.0"
 babel==2.9.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 backcall==0.2.0; python_version >= "3.8"
 backports.zoneinfo==0.2.1; python_version < "3.9" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 bandit==1.7.2; python_version >= "3.7"
 beartype==0.7.1; python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0"
-beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.7"
+beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.5"
 black==21.7b0; python_full_version >= "3.6.2"
 bleach==4.1.0; python_version >= "3.7"
 bs4==0.0.1
 bt==0.2.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 cachetools==5.0.0; python_version >= "3.7" and python_version < "4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
-certifi==2021.10.8; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
-cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
+certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.6"
 cfgv==3.3.1; python_full_version >= "3.6.1"
 chardet==4.0.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-charset-normalizer==2.0.11; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+charset-normalizer==2.0.11; python_full_version >= "3.6.0" and python_version >= "3"
 click==8.0.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 codespell==2.1.0; python_version >= "3.5"
-colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows" and python_version >= "3.6") and platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
+colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "2.7" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.6" and python_full_version >= "3.5.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
 commonmark==0.9.1; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 convertdate==2.4.0; python_version >= "3.7" and python_version < "4"
 coverage==6.3; python_version >= "3.7"
@@ -54,7 +54,7 @@ distlib==0.3.4; python_full_version >= "3.6.1"
 dnspython==2.2.0; python_version >= "3.6" and python_version < "4.0"
 docutils==0.16; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 ecos==2.0.10; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
-entrypoints==0.3; python_full_version >= "3.7.0" and python_version >= "3.7"
+entrypoints==0.3; python_full_version >= "3.6.1" and python_version >= "3.7"
 et-xmlfile==1.1.0; python_version >= "3.6"
 exchange-calendars==3.5.1; python_version >= "3.7" and python_full_version >= "3.7.0"
 executing==0.8.2; python_version >= "3.8"
@@ -83,7 +83,7 @@ h5py==3.6.0; python_version >= "3.7"
 hijri-converter==2.2.2; python_version >= "3.6"
 holidays==0.11.3.1; python_version >= "3.6"
 identify==2.4.6; python_version >= "3.7" and python_full_version >= "3.6.1"
-idna==3.3; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+idna==3.3; python_full_version >= "3.6.2" and python_version >= "3.7"
 imagesize==1.3.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 importlib-metadata==4.10.1; python_version < "3.10" and python_version >= "3.7"
 inflection==0.5.1; python_version >= "3.6"
@@ -91,19 +91,19 @@ iniconfig==1.1.1; python_version >= "3.7"
 investpy==1.0.8; python_version >= "3.7"
 ipykernel==6.7.0; python_version >= "3.7"
 ipympl==0.8.7
-ipython-genutils==0.2.0; python_full_version >= "3.7.0" and python_version >= "3.7"
+ipython-genutils==0.2.0; python_version >= "3.7"
 ipython==8.0.1; python_version >= "3.8"
 ipywidgets==7.6.5
 iso8601==0.1.16
 isort==5.10.1; python_full_version >= "3.6.2" and python_version < "4.0"
 jedi==0.18.1; python_version >= "3.8"
 jinja2==3.0.3; python_version >= "3.7"
-joblib==1.1.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
+joblib==1.1.0; python_version >= "3.7"
 json5==0.9.6; python_version >= "3.6"
 jsonschema==3.2.0
 jupyter-client==7.1.2; python_full_version >= "3.7.0" and python_version >= "3.7"
 jupyter-console==6.4.0; python_version >= "3.6"
-jupyter-core==4.9.1; python_full_version >= "3.7.0" and python_version >= "3.7"
+jupyter-core==4.9.1; python_full_version >= "3.6.1" and python_version >= "3.7"
 jupyter-server==1.13.4; python_version >= "3.7"
 jupyter==1.0.0
 jupyterlab-pygments==0.1.2; python_version >= "3.7"
@@ -120,7 +120,7 @@ lxml==4.7.1; python_version >= "3.7" and python_full_version < "3.0.0" or python
 m2r2==0.2.8; python_version >= "3.7"
 markdown-it-py==1.1.0; python_version >= "3.6" and python_version < "4.0"
 markdown==3.3.6; python_version >= "3.6"
-markupsafe==2.0.1; python_version >= "3.7"
+markupsafe==2.0.1; python_version >= "3.6"
 matplotlib-inline==0.1.3; python_version >= "3.8"
 matplotlib==3.5.1; python_version >= "3.7"
 mccabe==0.6.1; python_full_version >= "3.6.2"
@@ -175,13 +175,13 @@ protobuf==3.19.4; python_full_version >= "3.7.1" and python_full_version < "4.0.
 psaw==0.0.12; python_version >= "3"
 ptyprocess==0.7.0; os_name != "nt" and python_version >= "3.8" and sys_platform != "win32"
 pure-eval==0.2.2; python_version >= "3.8"
-py==1.11.0; python_full_version >= "3.7.0" and python_version >= "3.7" and implementation_name == "pypy"
+py==1.11.0; python_version >= "3.7" and python_full_version < "3.0.0" and implementation_name == "pypy" or python_full_version >= "3.5.0" and python_version >= "3.7" and implementation_name == "pypy"
 pyally==1.1.2
 pyasn1-modules==0.2.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 pyasn1==0.4.8; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") or python_full_version >= "3.6.0" and python_version >= "3.6" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 pycodestyle==2.7.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pycoingecko==2.2.0
-pycparser==2.21; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
+pycparser==2.21; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 pyex==0.5.0
 pyflakes==2.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pygments==2.11.2; python_version >= "3.5"
@@ -196,21 +196,22 @@ pyparsing==3.0.7; python_version >= "3.7"
 pyportfolioopt==1.5.1; python_full_version >= "3.6.1" and python_full_version < "4.0.0"
 pyprind==2.11.3; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 pyrsistent==0.18.1; python_version >= "3.7"
+pytest-cov==3.0.0; python_version >= "3.6"
 pytest-mock==3.7.0; python_version >= "3.7"
 pytest-recording==0.12.0; python_version >= "3.5"
 pytest==6.2.5; python_version >= "3.6"
 python-binance==1.0.15
 python-coinmarketcap==0.2
-python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
+python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
 python-dotenv==0.19.2; python_version >= "3.5"
 pytrends==4.7.3
 pytz-deprecation-shim==0.1.0.post0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
+pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
 pyupgrade==2.31.0; python_full_version >= "3.6.1"
-pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.7" and python_full_version >= "3.7.0"
+pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.6"
 pywinpty==2.0.1; os_name == "nt" and python_version >= "3.7"
 pyyaml==6.0; python_version >= "3.7" and python_full_version >= "3.6.1"
-pyzmq==22.3.0; python_full_version >= "3.7.0" and python_version >= "3.7"
+pyzmq==22.3.0; python_full_version >= "3.6.1" and python_version >= "3.7"
 qdldl==0.1.5.post0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 qtconsole==5.2.2; python_version >= "3.6"
 qtpy==2.0.0; python_version >= "3.6"
@@ -224,7 +225,7 @@ rich==10.16.2; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 robin-stocks==2.1.0; python_version >= "3"
 rsa==4.8; python_version >= "3.6" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 scikit-learn==1.0.2; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
-scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
 screeninfo==0.6.7
 scs==3.1.0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 seaborn==0.11.2; python_version >= "3.6"
@@ -232,7 +233,7 @@ selenium==3.141.0
 send2trash==1.8.0; python_version >= "3.7"
 sentiment-investor==2.1.0; python_version >= "3.8" and python_version < "4.0"
 setuptools-scm==6.4.2; python_version >= "3.7"
-six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
+six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
 smmap==5.0.0; python_version >= "3.7"
 sniffio==1.2.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 snowballstemmer==2.2.0; python_version >= "3.7"
@@ -264,12 +265,12 @@ terminado==0.13.1; python_version >= "3.7"
 testpath==0.5.0; python_version >= "3.7"
 textwrap3==0.9.2; python_version >= "3.6"
 thepassiveinvestor==1.0.10
-threadpoolctl==3.0.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
+threadpoolctl==3.0.0; python_version >= "3.7"
 tokenize-rt==4.2.1; python_full_version >= "3.6.1"
 toml==0.10.2; python_full_version >= "3.6.2" and python_version >= "3.6" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7")
 tomli==1.2.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 toolz==0.11.2; python_version >= "3.7" and python_full_version >= "3.7.0"
-tornado==6.1; python_full_version >= "3.7.0" and python_version >= "3.7"
+tornado==6.1; python_full_version >= "3.6.1" and python_version >= "3.7"
 tqdm==4.62.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 tradingview-ta==3.2.10; python_version >= "3.6"
 traitlets==5.1.1; python_full_version >= "3.7.0" and python_version >= "3.8"
@@ -285,14 +286,14 @@ tzlocal==4.1; python_version >= "3.6"
 ujson==5.1.0; python_version >= "3.7"
 unidecode==1.3.2; python_version >= "3.7"
 update-checker==0.18.0; python_version >= "3.6" and python_version < "4.0"
-urllib3==1.26.8; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.8" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+urllib3==1.26.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 user-agent==0.1.10
 vadersentiment==3.3.2
 valinvest==0.0.2; python_version >= "3.6"
 vcrpy==4.1.1; python_version >= "3.5"
 virtualenv==20.13.0; python_full_version >= "3.6.1"
 voila==0.3.1; python_version >= "3.7"
-wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.8"
+wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.6"
 webencodings==0.5.1; python_version >= "3.7"
 websocket-client==1.2.3; python_version >= "3.8" and python_version < "4.0"
 websockets==9.1; python_full_version >= "3.6.1" and python_version >= "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,29 +5,35 @@ ansiwrap==0.8.4; python_version >= "3.6"
 anyio==3.5.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 appdirs==1.4.4; python_full_version >= "3.6.2" and python_version >= "3.8"
 appnope==0.1.2; platform_system == "Darwin" and python_version >= "3.8" and sys_platform == "darwin"
-argon2-cffi-bindings==21.2.0; python_version >= "3.7"
+argon2-cffi-bindings==21.2.0; python_version >= "3.6"
 argon2-cffi==21.3.0; python_version >= "3.7"
 ascii-magic==1.6; python_version >= "3.5"
+astroid==2.9.3; python_full_version >= "3.6.2"
 asttokens==2.0.5; python_version >= "3.8"
 async-timeout==3.0.1; python_full_version >= "3.5.3" and python_version >= "3.6"
-attrs==21.4.0; python_full_version >= "3.7.0" and python_version >= "3.7"
+atomicwrites==1.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.4.0"
+attrs==21.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.7" and python_version < "4.0"
 babel==2.9.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 backcall==0.2.0; python_version >= "3.8"
 backports.zoneinfo==0.2.1; python_version < "3.9" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
+bandit==1.7.2; python_version >= "3.7"
 beartype==0.7.1; python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0"
-beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.7"
+beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.5"
 black==21.7b0; python_full_version >= "3.6.2"
 bleach==4.1.0; python_version >= "3.7"
 bs4==0.0.1
 bt==0.2.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
-certifi==2021.10.8; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
-cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
+certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.6"
+cfgv==3.3.1; python_full_version >= "3.6.1"
 chardet==4.0.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-charset-normalizer==2.0.11; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+charset-normalizer==2.0.11; python_full_version >= "3.6.0" and python_version >= "3"
 click==8.0.3; python_version >= "3.8" and python_full_version >= "3.6.2"
-colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows" and python_version >= "3.6") and platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
+codespell==2.1.0; python_version >= "3.5"
+colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "2.7" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.6" and python_full_version >= "3.5.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
 commonmark==0.9.1; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 convertdate==2.4.0; python_version >= "3.7" and python_version < "4"
+coverage==6.3; python_version >= "3.7"
 cryptography==36.0.1; python_version >= "3.6"
 cssselect==1.1.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0"
 cvxpy==1.1.18; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
@@ -41,17 +47,21 @@ defusedxml==0.7.1; python_version >= "3.7" and python_full_version < "3.0.0" or 
 degiro-connector==2.0.15; python_full_version >= "3.7.1" and python_full_version < "4.0.0"
 deprecation==2.1.0
 detecta==0.0.5; python_version >= "3.6"
+distlib==0.3.4; python_full_version >= "3.6.1"
 dnspython==2.2.0; python_version >= "3.6" and python_version < "4.0"
 docutils==0.16; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 ecos==2.0.10; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
-entrypoints==0.3; python_full_version >= "3.7.0" and python_version >= "3.7"
+entrypoints==0.3; python_full_version >= "3.6.1" and python_version >= "3.7"
 et-xmlfile==1.1.0; python_version >= "3.6"
+exchange-calendars==3.5.1; python_version >= "3.7" and python_full_version >= "3.7.0"
 executing==0.8.2; python_version >= "3.8"
 fear-greed-index==0.1.4; python_version >= "3.7"
 ffn==0.3.6; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
+filelock==3.4.2; python_version >= "3.7" and python_full_version >= "3.6.1"
 financedatabase==1.0.2
 finviz==1.4.3
 finvizfinance==0.9.10; python_version >= "3.5"
+flake8==3.9.2; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.5.0")
 fonttools==4.29.0; python_version >= "3.7"
 fred==3.1
 fredapi==0.4.3
@@ -63,24 +73,27 @@ gitpython==3.1.26; python_version >= "3.7"
 grpcio==1.43.0; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 hijri-converter==2.2.2; python_version >= "3.6"
 holidays==0.11.3.1; python_version >= "3.6"
-idna==3.3; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+identify==2.4.6; python_version >= "3.7" and python_full_version >= "3.6.1"
+idna==3.3; python_full_version >= "3.6.2" and python_version >= "3.7"
 imagesize==1.3.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 inflection==0.5.1; python_version >= "3.6"
+iniconfig==1.1.1; python_version >= "3.7"
 investpy==1.0.8; python_version >= "3.7"
 ipykernel==6.7.0; python_version >= "3.7"
 ipympl==0.8.7
-ipython-genutils==0.2.0; python_full_version >= "3.7.0" and python_version >= "3.7"
+ipython-genutils==0.2.0; python_version >= "3.7"
 ipython==8.0.1; python_version >= "3.8"
 ipywidgets==7.6.5
 iso8601==0.1.16
+isort==5.10.1; python_full_version >= "3.6.2" and python_version < "4.0"
 jedi==0.18.1; python_version >= "3.8"
 jinja2==3.0.3; python_version >= "3.7"
-joblib==1.1.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
+joblib==1.1.0; python_version >= "3.7"
 json5==0.9.6; python_version >= "3.6"
 jsonschema==3.2.0
 jupyter-client==7.1.2; python_full_version >= "3.7.0" and python_version >= "3.7"
 jupyter-console==6.4.0; python_version >= "3.6"
-jupyter-core==4.9.1; python_full_version >= "3.7.0" and python_version >= "3.7"
+jupyter-core==4.9.1; python_full_version >= "3.6.1" and python_version >= "3.7"
 jupyter-server==1.13.4; python_version >= "3.7"
 jupyter==1.0.0
 jupyterlab-pygments==0.1.2; python_version >= "3.7"
@@ -88,24 +101,31 @@ jupyterlab-server==2.10.3; python_version >= "3.6"
 jupyterlab-widgets==1.0.2; python_version >= "3.6"
 jupyterlab==3.2.8; python_version >= "3.6"
 kiwisolver==1.3.2; python_version >= "3.7"
-korean-lunar-calendar==0.2.1; python_version >= "3.6"
+korean-lunar-calendar==0.2.1; python_version >= "3.7" and python_full_version >= "3.7.0"
+lazy-object-proxy==1.7.1; python_version >= "3.6" and python_full_version >= "3.6.2"
 lxml==4.7.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 m2r2==0.2.8; python_version >= "3.7"
-markupsafe==2.0.1; python_version >= "3.7"
+markdown-it-py==1.1.0; python_version >= "3.6" and python_version < "4.0"
+markupsafe==2.0.1; python_version >= "3.6"
 matplotlib-inline==0.1.3; python_version >= "3.8"
 matplotlib==3.5.1; python_version >= "3.7"
+mccabe==0.6.1; python_full_version >= "3.6.2"
+mdit-py-plugins==0.2.8; python_version >= "3.6" and python_version < "4.0"
 mistune==0.8.4; python_version >= "3.7"
+mock==4.0.3; python_version >= "3.6"
 more-itertools==8.12.0; python_version >= "3.6"
 mplfinance==0.12.8b6
 multidict==6.0.2; python_version >= "3.7"
 multitasking==0.0.10
 mypy-extensions==0.4.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 mypy==0.930; python_version >= "3.6"
+myst-parser==0.15.2; python_version >= "3.6"
 nbclassic==0.3.5; python_version >= "3.6"
 nbclient==0.5.10; python_full_version >= "3.7.0" and python_version >= "3.7"
 nbconvert==6.4.1; python_version >= "3.7"
 nbformat==5.1.3; python_full_version >= "3.7.0" and python_version >= "3.7"
 nest-asyncio==1.5.4; python_full_version >= "3.7.0" and python_version >= "3.7"
+nodeenv==1.6.0; python_full_version >= "3.6.1"
 notebook==6.4.8; python_version >= "3.6"
 numpy==1.21.2; python_version >= "3.7" and python_version < "3.11"
 oandapyv20==0.6.3
@@ -115,6 +135,7 @@ openpyxl==3.0.9; python_version >= "3.6"
 osqp==0.6.2.post5; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 packaging==21.3; python_version >= "3.7"
 pandas-datareader==0.10.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
+pandas-market-calendars==3.3; python_full_version >= "3.7.0"
 pandas-ta==0.3.14b
 pandas==1.3.5; python_full_version >= "3.7.1"
 pandocfilters==1.5.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
@@ -122,25 +143,33 @@ papermill==2.3.4; python_version >= "3.6"
 parso==0.8.3; python_version >= "3.8"
 pathspec==0.9.0; python_full_version >= "3.6.2" and python_version >= "3.8"
 patsy==0.5.2; python_version >= "3.6"
+pbr==5.8.0; python_version >= "3.7"
 pexpect==4.8.0; sys_platform != "win32" and python_version >= "3.8"
 pickleshare==0.7.5; python_version >= "3.8"
 pillow==9.0.0; python_version >= "3.7" and python_version < "4"
+platformdirs==2.4.1; python_version >= "3.7" and python_full_version >= "3.6.2"
 plotly==5.5.0; python_version >= "3.6"
+pluggy==1.0.0; python_version >= "3.7"
 pmdarima==1.8.4; python_version >= "3.6"
 praw==7.5.0; python_version >= "3.6" and python_version < "4.0"
 prawcore==2.3.0; python_version >= "3.6" and python_version < "4.0"
+pre-commit==2.17.0; python_full_version >= "3.6.1"
 prometheus-client==0.13.1; python_version >= "3.7"
 prompt-toolkit==3.0.26; python_full_version >= "3.6.2"
 protobuf==3.19.4; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and python_version >= "3.5"
 psaw==0.0.12; python_version >= "3"
 ptyprocess==0.7.0; os_name != "nt" and python_version >= "3.8" and sys_platform != "win32"
 pure-eval==0.2.2; python_version >= "3.8"
-py==1.11.0; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
+py==1.11.0; python_version >= "3.7" and python_full_version < "3.0.0" and implementation_name == "pypy" or python_full_version >= "3.5.0" and python_version >= "3.7" and implementation_name == "pypy"
 pyally==1.1.2
+pycodestyle==2.7.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pycoingecko==2.2.0
-pycparser==2.21; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
+pycparser==2.21; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 pyex==0.5.0
+pyflakes==2.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pygments==2.11.2; python_version >= "3.5"
+pylint==2.12.2; python_full_version >= "3.6.2"
+pyluach==1.3.0; python_version >= "3.7" and python_full_version >= "3.7.0"
 pymeeus==0.5.11; python_version >= "3.7" and python_version < "4"
 pymongo==3.11.0; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.4.0")
 pyobjc-core==8.2; python_version >= "3.6" and sys_platform == "darwin"
@@ -150,17 +179,22 @@ pyparsing==3.0.7; python_version >= "3.7"
 pyportfolioopt==1.5.1; python_full_version >= "3.6.1" and python_full_version < "4.0.0"
 pyprind==2.11.3; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 pyrsistent==0.18.1; python_version >= "3.7"
+pytest-cov==3.0.0; python_version >= "3.6"
+pytest-mock==3.7.0; python_version >= "3.7"
+pytest-recording==0.12.0; python_version >= "3.5"
+pytest==6.2.5; python_version >= "3.6"
 python-binance==1.0.15
 python-coinmarketcap==0.2
-python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
+python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
 python-dotenv==0.19.2; python_version >= "3.5"
 pytrends==4.7.3
 pytz-deprecation-shim==0.1.0.post0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
-pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.7" and python_full_version >= "3.7.0"
+pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
+pyupgrade==2.31.0; python_full_version >= "3.6.1"
+pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.6"
 pywinpty==2.0.1; os_name == "nt" and python_version >= "3.7"
-pyyaml==6.0; python_version >= "3.6"
-pyzmq==22.3.0; python_full_version >= "3.7.0" and python_version >= "3.7"
+pyyaml==6.0; python_version >= "3.7" and python_full_version >= "3.6.1"
+pyzmq==22.3.0; python_full_version >= "3.6.1" and python_version >= "3.7"
 qdldl==0.1.5.post0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 qtconsole==5.2.2; python_version >= "3.6"
 qtpy==2.0.0; python_version >= "3.6"
@@ -173,7 +207,7 @@ requests==2.27.1; (python_version >= "2.7" and python_full_version < "3.0.0") or
 rich==10.16.2; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 robin-stocks==2.1.0; python_version >= "3"
 scikit-learn==1.0.2; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
-scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
 screeninfo==0.6.7
 scs==3.1.0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 seaborn==0.11.2; python_version >= "3.6"
@@ -181,7 +215,7 @@ selenium==3.141.0
 send2trash==1.8.0; python_version >= "3.7"
 sentiment-investor==2.1.0; python_version >= "3.8" and python_version < "4.0"
 setuptools-scm==6.4.2; python_version >= "3.7"
-six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
+six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
 smmap==5.0.0; python_version >= "3.7"
 sniffio==1.2.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 snowballstemmer==2.2.0; python_version >= "3.7"
@@ -198,6 +232,7 @@ sphinxcontrib-serializinghtml==1.1.5; python_version >= "3.7"
 sseclient==0.0.27
 stack-data==0.1.4; python_version >= "3.8"
 statsmodels==0.12.2; python_version >= "3.6"
+stevedore==3.5.0; python_version >= "3.7"
 tabulate==0.8.9; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
 temporal-cache==0.1.4
 tenacity==8.0.1; python_version >= "3.6"
@@ -205,29 +240,40 @@ terminado==0.13.1; python_version >= "3.7"
 testpath==0.5.0; python_version >= "3.7"
 textwrap3==0.9.2; python_version >= "3.6"
 thepassiveinvestor==1.0.10
-threadpoolctl==3.0.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
+threadpoolctl==3.0.0; python_version >= "3.7"
+tokenize-rt==4.2.1; python_full_version >= "3.6.1"
+toml==0.10.2; python_full_version >= "3.6.2" and python_version >= "3.6" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7")
 tomli==1.2.3; python_version >= "3.8" and python_full_version >= "3.6.2"
-tornado==6.1; python_full_version >= "3.7.0" and python_version >= "3.7"
+toolz==0.11.2; python_version >= "3.7" and python_full_version >= "3.7.0"
+tornado==6.1; python_full_version >= "3.6.1" and python_version >= "3.7"
 tqdm==4.62.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 tradingview-ta==3.2.10; python_version >= "3.6"
 traitlets==5.1.1; python_full_version >= "3.7.0" and python_version >= "3.8"
-typing-extensions==4.0.1; python_version >= "3.6"
+types-python-dateutil==2.8.9
+types-pytz==2021.3.4
+types-pyyaml==6.0.3
+types-requests==2.27.7
+types-setuptools==57.4.8
+types-urllib3==1.26.8
+typing-extensions==4.0.1; python_version < "3.10" and python_full_version >= "3.6.2" and python_version >= "3.6"
 tzdata==2021.5; platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 tzlocal==4.1; python_version >= "3.6"
 ujson==5.1.0; python_version >= "3.7"
 unidecode==1.3.2; python_version >= "3.7"
 update-checker==0.18.0; python_version >= "3.6" and python_version < "4.0"
-urllib3==1.26.8; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.8" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+urllib3==1.26.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
 user-agent==0.1.10
 vadersentiment==3.3.2
 valinvest==0.0.2; python_version >= "3.6"
+vcrpy==4.1.1; python_version >= "3.5"
+virtualenv==20.13.0; python_full_version >= "3.6.1"
 voila==0.3.1; python_version >= "3.7"
-wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.8"
+wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.6"
 webencodings==0.5.1; python_version >= "3.7"
 websocket-client==1.2.3; python_version >= "3.8" and python_version < "4.0"
 websockets==9.1; python_full_version >= "3.6.1" and python_version >= "3.7"
 widgetsnbextension==3.5.2
-wrapt==1.13.3; python_full_version >= "3.7.1" and python_full_version < "4.0.0"
+wrapt==1.13.3; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5")
 yarl==1.7.2; python_version >= "3.6"
 yfinance==0.1.70
 zope.interface==5.4.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"


### PR DESCRIPTION
# Description
Look like `pytest-cov` was missing from `dev-dependencies`


# How has this been tested?
With `poetry install` command


# Checklist:

- [x] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
