### PR TITLE
Sort Stocks/DD/Arktrades by most recent

### DIFF
--- a/gamestonk_terminal/stocks/due_diligence/ark_model.py
+++ b/gamestonk_terminal/stocks/due_diligence/ark_model.py
@@ -67,4 +67,4 @@ def get_ark_trades_by_ticker(ticker: str) -> pd.DataFrame:
     df_orders.index = pd.DatetimeIndex(df_orders.index)
     df_orders = df_orders.join(prices)
     df_orders["Total"] = df_orders["Close"] * df_orders["shares"]
-    return df_orders
+    return df_orders.sort_index(ascending=False)


### PR DESCRIPTION
# Description
- Items are displayed by oldest first, resulting in no current results being found. Fix to display results by newest-to-oldest
- Issue is described [here](https://github.com/GamestonkTerminal/GamestonkTerminal/issues/1359) 

<img width="934" alt="image" src="https://user-images.githubusercontent.com/40023817/154198457-4cf2d1bf-9335-450f-9172-3e35cfd0c939.png">

- [ ] Summary of the change / bug fix.
- [ ] Link # issue, if applicable.
- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context. 
- [ ] List any dependencies that are required for this change.


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [ ] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
