### PR TITLE
Bump tensorflow version to mitigate vulnerabilities

### DIFF
--- a/bots/requirements.txt
+++ b/bots/requirements.txt
@@ -5,33 +5,33 @@ ansiwrap==0.8.4; python_version >= "3.6"
 anyio==3.5.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 appdirs==1.4.4; python_full_version >= "3.6.2" and python_version >= "3.8"
 appnope==0.1.2; platform_system == "Darwin" and python_version >= "3.8" and sys_platform == "darwin"
-argon2-cffi-bindings==21.2.0; python_version >= "3.6"
+argon2-cffi-bindings==21.2.0; python_version >= "3.7"
 argon2-cffi==21.3.0; python_version >= "3.7"
 ascii-magic==1.6; python_version >= "3.5"
 asgiref==3.5.0; python_version >= "3.7"
 astroid==2.9.3; python_full_version >= "3.6.2"
 asttokens==2.0.5; python_version >= "3.8"
-async-timeout==3.0.1; python_full_version >= "3.5.3" and python_version >= "3.6"
+async-timeout==3.0.1; python_version >= "3.6" and python_full_version >= "3.8.0"
 atomicwrites==1.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.4.0"
-attrs==21.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.7" and python_version < "4.0"
+attrs==21.4.0; python_full_version >= "3.8.0" and python_version >= "3.7" and (python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.6" and python_version < "4.0" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7")
 babel==2.9.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 backcall==0.2.0; python_version >= "3.8"
 backports.zoneinfo==0.2.1; python_version < "3.9" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 bandit==1.7.2; python_version >= "3.7"
 beartype==0.7.1; python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0"
-beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.5"
+beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.7"
 black==21.7b0; python_full_version >= "3.6.2"
 bleach==4.1.0; python_version >= "3.7"
 bs4==0.0.1
 bt==0.2.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
-certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
-cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.6"
+certifi==2021.10.8; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 cfgv==3.3.1; python_full_version >= "3.6.1"
-chardet==4.0.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-charset-normalizer==2.0.11; python_full_version >= "3.6.0" and python_version >= "3"
+chardet==4.0.0; python_version >= "3.6" and python_full_version >= "3.8.0"
+charset-normalizer==2.0.11; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 click==8.0.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 codespell==2.1.0; python_version >= "3.5"
-colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "2.7" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.6" and python_full_version >= "3.5.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
+colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows" and python_version >= "3.6") and platform_system == "Windows" and python_version >= "3.7" and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
 commonmark==0.9.1; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 convertdate==2.4.0; python_version >= "3.7" and python_version < "4"
 coverage==6.3; python_version >= "3.7"
@@ -54,7 +54,7 @@ distlib==0.3.4; python_full_version >= "3.6.1"
 dnspython==2.2.0; python_version >= "3.6" and python_version < "4.0"
 docutils==0.16; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 ecos==2.0.10; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
-entrypoints==0.3; python_full_version >= "3.6.1" and python_version >= "3.7"
+entrypoints==0.3; python_full_version >= "3.7.0" and python_version >= "3.7"
 et-xmlfile==1.1.0; python_version >= "3.6"
 exchange-calendars==3.5.1; python_version >= "3.7" and python_full_version >= "3.7.0"
 executing==0.8.2; python_version >= "3.8"
@@ -79,26 +79,26 @@ h11==0.13.0; python_version >= "3.7"
 hijri-converter==2.2.2; python_version >= "3.6"
 holidays==0.11.3.1; python_version >= "3.6"
 identify==2.4.6; python_version >= "3.7" and python_full_version >= "3.6.1"
-idna==3.3; python_full_version >= "3.6.2" and python_version >= "3.7"
+idna==3.3; python_full_version >= "3.8.0" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 imagesize==1.3.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 inflection==0.5.1; python_version >= "3.6"
 iniconfig==1.1.1; python_version >= "3.7"
 investpy==1.0.8; python_version >= "3.7"
 ipykernel==6.7.0; python_version >= "3.7"
 ipympl==0.8.7
-ipython-genutils==0.2.0; python_version >= "3.7"
+ipython-genutils==0.2.0; python_full_version >= "3.7.0" and python_version >= "3.7"
 ipython==8.0.1; python_version >= "3.8"
 ipywidgets==7.6.5
 iso8601==0.1.16
 isort==5.10.1; python_full_version >= "3.6.2" and python_version < "4.0"
 jedi==0.18.1; python_version >= "3.8"
 jinja2==3.0.3; python_version >= "3.7"
-joblib==1.1.0; python_version >= "3.7"
+joblib==1.1.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 json5==0.9.6; python_version >= "3.6"
 jsonschema==3.2.0
 jupyter-client==7.1.2; python_full_version >= "3.7.0" and python_version >= "3.7"
 jupyter-console==6.4.0; python_version >= "3.6"
-jupyter-core==4.9.1; python_full_version >= "3.6.1" and python_version >= "3.7"
+jupyter-core==4.9.1; python_full_version >= "3.7.0" and python_version >= "3.7"
 jupyter-server==1.13.4; python_version >= "3.7"
 jupyter==1.0.0
 jupyterlab-pygments==0.1.2; python_version >= "3.7"
@@ -112,7 +112,7 @@ lazy-object-proxy==1.7.1; python_version >= "3.6" and python_full_version >= "3.
 lxml==4.7.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 m2r2==0.2.8; python_version >= "3.7"
 markdown-it-py==1.1.0; python_version >= "3.6" and python_version < "4.0"
-markupsafe==2.0.1; python_version >= "3.6"
+markupsafe==2.0.1; python_version >= "3.7"
 matplotlib-inline==0.1.3; python_version >= "3.8"
 matplotlib==3.5.1; python_version >= "3.7"
 mccabe==0.6.1; python_full_version >= "3.6.2"
@@ -121,7 +121,7 @@ mistune==0.8.4; python_version >= "3.7"
 mock==4.0.3; python_version >= "3.6"
 more-itertools==8.12.0; python_version >= "3.6"
 mplfinance==0.12.8b6
-multidict==6.0.2; python_version >= "3.7"
+multidict==6.0.2; python_version >= "3.7" and python_full_version >= "3.8.0"
 multitasking==0.0.10
 mypy-extensions==0.4.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 mypy==0.930; python_version >= "3.6"
@@ -166,7 +166,7 @@ protobuf==3.19.4; python_full_version >= "3.7.1" and python_full_version < "4.0.
 psaw==0.0.12; python_version >= "3"
 ptyprocess==0.7.0; os_name != "nt" and python_version >= "3.8" and sys_platform != "win32"
 pure-eval==0.2.2; python_version >= "3.8"
-py==1.11.0; python_version >= "3.7" and python_full_version < "3.0.0" and implementation_name == "pypy" or python_full_version >= "3.5.0" and python_version >= "3.7" and implementation_name == "pypy"
+py==1.11.0; python_full_version >= "3.7.0" and python_version >= "3.7" and implementation_name == "pypy"
 pyally==1.1.2
 pycodestyle==2.7.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pycoingecko==2.2.0
@@ -194,16 +194,16 @@ pytest-recording==0.12.0; python_version >= "3.5"
 pytest==6.2.5; python_version >= "3.6"
 python-binance==1.0.15
 python-coinmarketcap==0.2
-python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
+python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.8" and python_full_version < "4.0.0" and python_version < "4.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
 python-dotenv==0.19.2; python_version >= "3.5"
 pytrends==4.7.3
 pytz-deprecation-shim==0.1.0.post0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
+pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.8" and python_full_version < "4.0.0" and python_version < "4.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
 pyupgrade==2.31.0; python_full_version >= "3.6.1"
-pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.6"
+pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 pywinpty==2.0.1; os_name == "nt" and python_version >= "3.7"
 pyyaml==6.0; python_version >= "3.7" and python_full_version >= "3.6.1"
-pyzmq==22.3.0; python_full_version >= "3.6.1" and python_version >= "3.7"
+pyzmq==22.3.0; python_full_version >= "3.7.0" and python_version >= "3.7"
 qdldl==0.1.5.post0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 qtconsole==5.2.2; python_version >= "3.6"
 qtpy==2.0.0; python_version >= "3.6"
@@ -216,7 +216,7 @@ requests==2.27.1; (python_version >= "2.7" and python_full_version < "3.0.0") or
 rich==10.16.2; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 robin-stocks==2.1.0; python_version >= "3"
 scikit-learn==1.0.2; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
-scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
+scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 screeninfo==0.6.7
 scs==3.1.0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 seaborn==0.11.2; python_version >= "3.6"
@@ -224,7 +224,7 @@ selenium==3.141.0
 send2trash==1.8.0; python_version >= "3.7"
 sentiment-investor==2.1.0; python_version >= "3.8" and python_version < "4.0"
 setuptools-scm==6.4.2; python_version >= "3.7"
-six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.3.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
+six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.8" and python_full_version < "4.0.0" and python_version < "4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and python_version < "4.0" or python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.3.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
 smmap==5.0.0; python_version >= "3.7"
 sniffio==1.2.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 snowballstemmer==2.2.0; python_version >= "3.7"
@@ -250,12 +250,12 @@ terminado==0.13.1; python_version >= "3.7"
 testpath==0.5.0; python_version >= "3.7"
 textwrap3==0.9.2; python_version >= "3.6"
 thepassiveinvestor==1.0.10
-threadpoolctl==3.0.0; python_version >= "3.7"
+threadpoolctl==3.0.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 tokenize-rt==4.2.1; python_full_version >= "3.6.1"
 toml==0.10.2; python_full_version >= "3.6.2" and python_version >= "3.6" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7")
 tomli==1.2.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 toolz==0.11.2; python_version >= "3.7" and python_full_version >= "3.7.0"
-tornado==6.1; python_full_version >= "3.6.1" and python_version >= "3.7"
+tornado==6.1; python_full_version >= "3.7.0" and python_version >= "3.7"
 tqdm==4.62.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 tradingview-ta==3.2.10; python_version >= "3.6"
 traitlets==5.1.1; python_full_version >= "3.7.0" and python_version >= "3.8"
@@ -265,13 +265,13 @@ types-pyyaml==6.0.3
 types-requests==2.27.7
 types-setuptools==57.4.8
 types-urllib3==1.26.8
-typing-extensions==4.0.1; python_version < "3.10" and python_full_version >= "3.6.2" and python_version >= "3.6"
+typing-extensions==4.0.1; python_version < "3.10" and python_full_version >= "3.8.0" and python_version >= "3.6"
 tzdata==2021.5; platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 tzlocal==4.1; python_version >= "3.6"
 ujson==5.1.0; python_version >= "3.7"
 unidecode==1.3.2; python_version >= "3.7"
 update-checker==0.18.0; python_version >= "3.6" and python_version < "4.0"
-urllib3==1.26.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
+urllib3==1.26.8; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.8" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 user-agent==0.1.10
 uvicorn==0.17.1; python_version >= "3.7"
 vadersentiment==3.3.2
@@ -279,12 +279,12 @@ valinvest==0.0.2; python_version >= "3.6"
 vcrpy==4.1.1; python_version >= "3.5"
 virtualenv==20.13.0; python_full_version >= "3.6.1"
 voila==0.3.1; python_version >= "3.7"
-wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.6"
+wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.8"
 webencodings==0.5.1; python_version >= "3.7"
 websocket-client==1.2.3; python_version >= "3.8" and python_version < "4.0"
 websockets==9.1; python_full_version >= "3.6.1" and python_version >= "3.7"
 widgetsnbextension==3.5.2
 wrapt==1.13.3; python_full_version >= "3.7.1" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5")
-yarl==1.7.2; python_version >= "3.6"
+yarl==1.7.2; python_version >= "3.6" and python_full_version >= "3.8.0"
 yfinance==0.1.70
 zope.interface==5.4.0; python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5"

--- a/poetry.lock
+++ b/poetry.lock
@@ -3423,7 +3423,7 @@ python-versions = "*"
 
 [[package]]
 name = "tensorflow"
-version = "2.7.0"
+version = "2.7.1"
 description = "TensorFlow is an open source machine learning framework for everyone."
 category = "main"
 optional = true
@@ -3963,7 +3963,7 @@ prediction = ["tensorflow"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.10"
-content-hash = "a17036617d87b60e3a7c60bd68f502ae6c1c6173e904bad87f9720940902fae7"
+content-hash = "426e697253a362a98c19fe7ebfacca2b696924ba35095d92986026084b42b883"
 
 [metadata.files]
 absl-py = [
@@ -4255,6 +4255,9 @@ coverage = [
     {file = "coverage-6.3-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:2bc85664b06ba42d14bb74d6ddf19d8bfc520cb660561d2d9ce5786ae72f71b5"},
     {file = "coverage-6.3-cp310-cp310-win32.whl", hash = "sha256:27a94db5dc098c25048b0aca155f5fac674f2cf1b1736c5272ba28ead2fc267e"},
     {file = "coverage-6.3-cp310-cp310-win_amd64.whl", hash = "sha256:bde4aeabc0d1b2e52c4036c54440b1ad05beeca8113f47aceb4998bb7471e2c2"},
+    {file = "coverage-6.3-cp311-cp311-macosx_10_14_x86_64.whl", hash = "sha256:509c68c3e2015022aeda03b003dd68fa19987cdcf64e9d4edc98db41cfc45d30"},
+    {file = "coverage-6.3-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:e4ff163602c5c77e7bb4ea81ba5d3b793b4419f8acd296aae149370902cf4e92"},
+    {file = "coverage-6.3-cp311-cp311-win_amd64.whl", hash = "sha256:d1675db48490e5fa0b300f6329ecb8a9a37c29b9ab64fa9c964d34111788ca2d"},
     {file = "coverage-6.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:7eed8459a2b81848cafb3280b39d7d49950d5f98e403677941c752e7e7ee47cb"},
     {file = "coverage-6.3-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b4285fde5286b946835a1a53bba3ad41ef74285ba9e8013e14b5ea93deaeafc"},
     {file = "coverage-6.3-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:a4748349734110fd32d46ff8897b561e6300d8989a494ad5a0a2e4f0ca974fc7"},
@@ -6305,15 +6308,15 @@ tensorboard-plugin-wit = [
     {file = "tensorboard_plugin_wit-1.8.1-py3-none-any.whl", hash = "sha256:ff26bdd583d155aa951ee3b152b3d0cffae8005dc697f72b44a8e8c2a77a8cbe"},
 ]
 tensorflow = [
-    {file = "tensorflow-2.7.0-cp37-cp37m-macosx_10_11_x86_64.whl", hash = "sha256:12f19d6c7161ffef21e69a14e60aaaf47dc25bff133ac954839f1308262b29bf"},
-    {file = "tensorflow-2.7.0-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:be0a2e3460dacc4214eedd6484b11e50583cb790ed37c6872378100fcaff1090"},
-    {file = "tensorflow-2.7.0-cp37-cp37m-win_amd64.whl", hash = "sha256:8f6066b1cbd33e47beb5a35df0f06c60d59d1e0b02ac420789b7679e8d879c70"},
-    {file = "tensorflow-2.7.0-cp38-cp38-macosx_10_11_x86_64.whl", hash = "sha256:eb653c85bdd00ca2dba6104b1a04c37eaffccec47e5357a0f57d7b9ee9a678c0"},
-    {file = "tensorflow-2.7.0-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:62db938367757c9fb54c56fa2fbbe3cd3bf05c046ee1da81667257fea554dc70"},
-    {file = "tensorflow-2.7.0-cp38-cp38-win_amd64.whl", hash = "sha256:a4539796c4ff8e7a3baaa6337cea237e49ec8f56a9c45f618a9642b474c0c8bd"},
-    {file = "tensorflow-2.7.0-cp39-cp39-macosx_10_11_x86_64.whl", hash = "sha256:e24b83eecf70d0467adbd5c5507a4f1a448b6df8cc586471d3decce8c50dd25f"},
-    {file = "tensorflow-2.7.0-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:ae17148d608a280c8d82d18404883367015e36cb1f4e02d34395d70a96912432"},
-    {file = "tensorflow-2.7.0-cp39-cp39-win_amd64.whl", hash = "sha256:7c7572de9f80547dcf3bcc2f94cd7d5dc14395d494c3b9d223e7b3e579a6b24f"},
+    {file = "tensorflow-2.7.1-cp37-cp37m-macosx_10_11_x86_64.whl", hash = "sha256:34b58fc1f0921dd679e9a03ffccfaee409c4df5c39a128c939555643e28bf94e"},
+    {file = "tensorflow-2.7.1-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:258a1ec62cd78b265c2f2ecc054dcdbfb4bc0ef8bd45cbeb6056cd0534b3b995"},
+    {file = "tensorflow-2.7.1-cp37-cp37m-win_amd64.whl", hash = "sha256:d1fb85258f013e0beb39cf3e69d362ee25d4cb5e94d0b0fa53019ede4ce5ae5d"},
+    {file = "tensorflow-2.7.1-cp38-cp38-macosx_10_11_x86_64.whl", hash = "sha256:3360fed07fd5f76a6627375ede5b9b23059e67fb4cab74f3192349bb548546e6"},
+    {file = "tensorflow-2.7.1-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:54c2aca9bb3c14a61ac56d8debe347f1b19fb5fd52d0d7372765952e53da45f6"},
+    {file = "tensorflow-2.7.1-cp38-cp38-win_amd64.whl", hash = "sha256:eb377e7da49a1a1b82be7ac5b93619fd2481b21fb3769d39f25971b431d6a024"},
+    {file = "tensorflow-2.7.1-cp39-cp39-macosx_10_11_x86_64.whl", hash = "sha256:634d4924f5f0c4e7a68d7549ce840e7c8c06f7dd8c7ec96a983eab15a707b331"},
+    {file = "tensorflow-2.7.1-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:0ed3ac84cda24bed5d24af5e6aeeb595b472fdc530efb9871bc79f830a0cb5f5"},
+    {file = "tensorflow-2.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:ed0843aa4978ca1f166167d3d638d80ff560eabceeb7bf0b77822df4b5d2f7aa"},
 ]
 tensorflow-estimator = [
     {file = "tensorflow_estimator-2.7.0-py2.py3-none-any.whl", hash = "sha256:325b5a224864379242b7b76c6987ca544239be82579d33e68ec7c2bda57abc9d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ pyimgur = {version = "^0.6.0", optional = true}
 python-dotenv = "^0.19.2"
 Pygments = "2.11.2"
 libclang = {version = "<12.0.0", optional = true}
-tensorflow = {version = "^2.7.0", optional = true}
+tensorflow = {version = "~2.7.1", optional = true}
 df2img = {version = "^0.2.4", optional = true}
 fastapi = {version = "^0.73.0", optional = true}
 uvicorn = {version = "^0.17.1", optional = true}

--- a/requirements-full.txt
+++ b/requirements-full.txt
@@ -6,7 +6,7 @@ ansiwrap==0.8.4; python_version >= "3.6"
 anyio==3.5.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 appdirs==1.4.4; python_full_version >= "3.6.2" and python_version >= "3.8"
 appnope==0.1.2; platform_system == "Darwin" and python_version >= "3.8" and sys_platform == "darwin"
-argon2-cffi-bindings==21.2.0; python_version >= "3.6"
+argon2-cffi-bindings==21.2.0; python_version >= "3.7"
 argon2-cffi==21.3.0; python_version >= "3.7"
 ascii-magic==1.6; python_version >= "3.5"
 astroid==2.9.3; python_full_version >= "3.6.2"
@@ -14,26 +14,26 @@ asttokens==2.0.5; python_version >= "3.8"
 astunparse==1.6.3
 async-timeout==3.0.1; python_full_version >= "3.5.3" and python_version >= "3.6"
 atomicwrites==1.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.4.0"
-attrs==21.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.7" and python_version < "4.0"
+attrs==21.4.0; python_full_version >= "3.7.0" and python_version >= "3.7" and python_version < "4.0"
 babel==2.9.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 backcall==0.2.0; python_version >= "3.8"
 backports.zoneinfo==0.2.1; python_version < "3.9" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 bandit==1.7.2; python_version >= "3.7"
 beartype==0.7.1; python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0"
-beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.5"
+beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.7"
 black==21.7b0; python_full_version >= "3.6.2"
 bleach==4.1.0; python_version >= "3.7"
 bs4==0.0.1
 bt==0.2.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
 cachetools==5.0.0; python_version >= "3.7" and python_version < "4.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
-certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
-cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.6"
+certifi==2021.10.8; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 cfgv==3.3.1; python_full_version >= "3.6.1"
 chardet==4.0.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-charset-normalizer==2.0.11; python_full_version >= "3.6.0" and python_version >= "3"
+charset-normalizer==2.0.11; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 click==8.0.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 codespell==2.1.0; python_version >= "3.5"
-colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "2.7" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.6" and python_full_version >= "3.5.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
+colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows" and python_version >= "3.6") and platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
 commonmark==0.9.1; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 convertdate==2.4.0; python_version >= "3.7" and python_version < "4"
 coverage==6.3; python_version >= "3.7"
@@ -54,7 +54,7 @@ distlib==0.3.4; python_full_version >= "3.6.1"
 dnspython==2.2.0; python_version >= "3.6" and python_version < "4.0"
 docutils==0.16; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 ecos==2.0.10; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
-entrypoints==0.3; python_full_version >= "3.6.1" and python_version >= "3.7"
+entrypoints==0.3; python_full_version >= "3.7.0" and python_version >= "3.7"
 et-xmlfile==1.1.0; python_version >= "3.6"
 exchange-calendars==3.5.1; python_version >= "3.7" and python_full_version >= "3.7.0"
 executing==0.8.2; python_version >= "3.8"
@@ -83,7 +83,7 @@ h5py==3.6.0; python_version >= "3.7"
 hijri-converter==2.2.2; python_version >= "3.6"
 holidays==0.11.3.1; python_version >= "3.6"
 identify==2.4.6; python_version >= "3.7" and python_full_version >= "3.6.1"
-idna==3.3; python_full_version >= "3.6.2" and python_version >= "3.7"
+idna==3.3; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 imagesize==1.3.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 importlib-metadata==4.10.1; python_version < "3.10" and python_version >= "3.7"
 inflection==0.5.1; python_version >= "3.6"
@@ -91,19 +91,19 @@ iniconfig==1.1.1; python_version >= "3.7"
 investpy==1.0.8; python_version >= "3.7"
 ipykernel==6.7.0; python_version >= "3.7"
 ipympl==0.8.7
-ipython-genutils==0.2.0; python_version >= "3.7"
+ipython-genutils==0.2.0; python_full_version >= "3.7.0" and python_version >= "3.7"
 ipython==8.0.1; python_version >= "3.8"
 ipywidgets==7.6.5
 iso8601==0.1.16
 isort==5.10.1; python_full_version >= "3.6.2" and python_version < "4.0"
 jedi==0.18.1; python_version >= "3.8"
 jinja2==3.0.3; python_version >= "3.7"
-joblib==1.1.0; python_version >= "3.7"
+joblib==1.1.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 json5==0.9.6; python_version >= "3.6"
 jsonschema==3.2.0
 jupyter-client==7.1.2; python_full_version >= "3.7.0" and python_version >= "3.7"
 jupyter-console==6.4.0; python_version >= "3.6"
-jupyter-core==4.9.1; python_full_version >= "3.6.1" and python_version >= "3.7"
+jupyter-core==4.9.1; python_full_version >= "3.7.0" and python_version >= "3.7"
 jupyter-server==1.13.4; python_version >= "3.7"
 jupyter==1.0.0
 jupyterlab-pygments==0.1.2; python_version >= "3.7"
@@ -120,7 +120,7 @@ lxml==4.7.1; python_version >= "3.7" and python_full_version < "3.0.0" or python
 m2r2==0.2.8; python_version >= "3.7"
 markdown-it-py==1.1.0; python_version >= "3.6" and python_version < "4.0"
 markdown==3.3.6; python_version >= "3.6"
-markupsafe==2.0.1; python_version >= "3.6"
+markupsafe==2.0.1; python_version >= "3.7"
 matplotlib-inline==0.1.3; python_version >= "3.8"
 matplotlib==3.5.1; python_version >= "3.7"
 mccabe==0.6.1; python_full_version >= "3.6.2"
@@ -175,13 +175,13 @@ protobuf==3.19.4; python_full_version >= "3.7.1" and python_full_version < "4.0.
 psaw==0.0.12; python_version >= "3"
 ptyprocess==0.7.0; os_name != "nt" and python_version >= "3.8" and sys_platform != "win32"
 pure-eval==0.2.2; python_version >= "3.8"
-py==1.11.0; python_version >= "3.7" and python_full_version < "3.0.0" and implementation_name == "pypy" or python_full_version >= "3.5.0" and python_version >= "3.7" and implementation_name == "pypy"
+py==1.11.0; python_full_version >= "3.7.0" and python_version >= "3.7" and implementation_name == "pypy"
 pyally==1.1.2
 pyasn1-modules==0.2.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
 pyasn1==0.4.8; python_version >= "3.6" and python_full_version < "3.0.0" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") or python_full_version >= "3.6.0" and python_version >= "3.6" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 pycodestyle==2.7.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pycoingecko==2.2.0
-pycparser==2.21; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+pycparser==2.21; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 pyex==0.5.0
 pyflakes==2.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pygments==2.11.2; python_version >= "3.5"
@@ -202,16 +202,16 @@ pytest-recording==0.12.0; python_version >= "3.5"
 pytest==6.2.5; python_version >= "3.6"
 python-binance==1.0.15
 python-coinmarketcap==0.2
-python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
+python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
 python-dotenv==0.19.2; python_version >= "3.5"
 pytrends==4.7.3
 pytz-deprecation-shim==0.1.0.post0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
+pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
 pyupgrade==2.31.0; python_full_version >= "3.6.1"
-pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.6"
+pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 pywinpty==2.0.1; os_name == "nt" and python_version >= "3.7"
 pyyaml==6.0; python_version >= "3.7" and python_full_version >= "3.6.1"
-pyzmq==22.3.0; python_full_version >= "3.6.1" and python_version >= "3.7"
+pyzmq==22.3.0; python_full_version >= "3.7.0" and python_version >= "3.7"
 qdldl==0.1.5.post0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 qtconsole==5.2.2; python_version >= "3.6"
 qtpy==2.0.0; python_version >= "3.6"
@@ -225,7 +225,7 @@ rich==10.16.2; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 robin-stocks==2.1.0; python_version >= "3"
 rsa==4.8; python_version >= "3.6" and python_version < "4" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 scikit-learn==1.0.2; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
-scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
+scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 screeninfo==0.6.7
 scs==3.1.0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 seaborn==0.11.2; python_version >= "3.6"
@@ -233,7 +233,7 @@ selenium==3.141.0
 send2trash==1.8.0; python_version >= "3.7"
 sentiment-investor==2.1.0; python_version >= "3.8" and python_version < "4.0"
 setuptools-scm==6.4.2; python_version >= "3.7"
-six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
+six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
 smmap==5.0.0; python_version >= "3.7"
 sniffio==1.2.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 snowballstemmer==2.2.0; python_version >= "3.7"
@@ -259,18 +259,18 @@ tensorboard-plugin-wit==1.8.1; python_version >= "3.6"
 tensorboard==2.8.0; python_version >= "3.6"
 tensorflow-estimator==2.7.0
 tensorflow-io-gcs-filesystem==0.23.1; python_version >= "3.7" and python_version < "3.11"
-tensorflow==2.7.0
+tensorflow==2.7.1
 termcolor==1.1.0
 terminado==0.13.1; python_version >= "3.7"
 testpath==0.5.0; python_version >= "3.7"
 textwrap3==0.9.2; python_version >= "3.6"
 thepassiveinvestor==1.0.10
-threadpoolctl==3.0.0; python_version >= "3.7"
+threadpoolctl==3.0.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 tokenize-rt==4.2.1; python_full_version >= "3.6.1"
 toml==0.10.2; python_full_version >= "3.6.2" and python_version >= "3.6" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7")
 tomli==1.2.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 toolz==0.11.2; python_version >= "3.7" and python_full_version >= "3.7.0"
-tornado==6.1; python_full_version >= "3.6.1" and python_version >= "3.7"
+tornado==6.1; python_full_version >= "3.7.0" and python_version >= "3.7"
 tqdm==4.62.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 tradingview-ta==3.2.10; python_version >= "3.6"
 traitlets==5.1.1; python_full_version >= "3.7.0" and python_version >= "3.8"
@@ -286,14 +286,14 @@ tzlocal==4.1; python_version >= "3.6"
 ujson==5.1.0; python_version >= "3.7"
 unidecode==1.3.2; python_version >= "3.7"
 update-checker==0.18.0; python_version >= "3.6" and python_version < "4.0"
-urllib3==1.26.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
+urllib3==1.26.8; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.8" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 user-agent==0.1.10
 vadersentiment==3.3.2
 valinvest==0.0.2; python_version >= "3.6"
 vcrpy==4.1.1; python_version >= "3.5"
 virtualenv==20.13.0; python_full_version >= "3.6.1"
 voila==0.3.1; python_version >= "3.7"
-wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.6"
+wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.8"
 webencodings==0.5.1; python_version >= "3.7"
 websocket-client==1.2.3; python_version >= "3.8" and python_version < "4.0"
 websockets==9.1; python_full_version >= "3.6.1" and python_version >= "3.7"

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,32 +5,32 @@ ansiwrap==0.8.4; python_version >= "3.6"
 anyio==3.5.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 appdirs==1.4.4; python_full_version >= "3.6.2" and python_version >= "3.8"
 appnope==0.1.2; platform_system == "Darwin" and python_version >= "3.8" and sys_platform == "darwin"
-argon2-cffi-bindings==21.2.0; python_version >= "3.6"
+argon2-cffi-bindings==21.2.0; python_version >= "3.7"
 argon2-cffi==21.3.0; python_version >= "3.7"
 ascii-magic==1.6; python_version >= "3.5"
 astroid==2.9.3; python_full_version >= "3.6.2"
 asttokens==2.0.5; python_version >= "3.8"
 async-timeout==3.0.1; python_full_version >= "3.5.3" and python_version >= "3.6"
 atomicwrites==1.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.4.0"
-attrs==21.4.0; python_version >= "3.7" and python_full_version < "3.0.0" and python_version < "4.0" or python_full_version >= "3.5.0" and python_version >= "3.7" and python_version < "4.0"
+attrs==21.4.0; python_full_version >= "3.7.0" and python_version >= "3.7" and python_version < "4.0"
 babel==2.9.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 backcall==0.2.0; python_version >= "3.8"
 backports.zoneinfo==0.2.1; python_version < "3.9" and python_version >= "3.6" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6")
 bandit==1.7.2; python_version >= "3.7"
 beartype==0.7.1; python_version >= "3.8" and python_version < "4.0" and python_full_version >= "3.6.0"
-beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.5"
+beautifulsoup4==4.10.0; python_full_version > "3.0.0" and python_version >= "3.7"
 black==21.7b0; python_full_version >= "3.6.2"
 bleach==4.1.0; python_version >= "3.7"
 bs4==0.0.1
 bt==0.2.9; (python_version >= "2.7" and python_full_version < "3.0.0") or (python_full_version >= "3.6.0")
-certifi==2021.10.8; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0"
-cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.6"
+certifi==2021.10.8; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
+cffi==1.15.0; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 cfgv==3.3.1; python_full_version >= "3.6.1"
 chardet==4.0.0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.6"
-charset-normalizer==2.0.11; python_full_version >= "3.6.0" and python_version >= "3"
+charset-normalizer==2.0.11; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 click==8.0.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 codespell==2.1.0; python_version >= "3.5"
-colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "2.7" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.6" and python_full_version >= "3.5.0") and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
+colorama==0.4.4; python_full_version >= "3.6.2" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.6" and python_full_version >= "3.5.0") and sys_platform == "win32" and (python_version >= "3.7" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.7" and python_full_version < "3.0.0" and platform_system == "Windows" or platform_system == "Windows" and python_version >= "3.7" and python_full_version >= "3.5.0") and (python_version >= "3.6" and python_full_version < "3.0.0" and platform_system == "Windows" or python_full_version >= "3.5.0" and platform_system == "Windows" and python_version >= "3.6") and platform_system == "Windows" and python_version >= "3.6" and (python_version >= "3.8" and python_full_version < "3.0.0" and sys_platform == "win32" or sys_platform == "win32" and python_version >= "3.8" and python_full_version >= "3.5.0")
 commonmark==0.9.1; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 convertdate==2.4.0; python_version >= "3.7" and python_version < "4"
 coverage==6.3; python_version >= "3.7"
@@ -51,7 +51,7 @@ distlib==0.3.4; python_full_version >= "3.6.1"
 dnspython==2.2.0; python_version >= "3.6" and python_version < "4.0"
 docutils==0.16; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0" and python_version >= "3.7"
 ecos==2.0.10; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
-entrypoints==0.3; python_full_version >= "3.6.1" and python_version >= "3.7"
+entrypoints==0.3; python_full_version >= "3.7.0" and python_version >= "3.7"
 et-xmlfile==1.1.0; python_version >= "3.6"
 exchange-calendars==3.5.1; python_version >= "3.7" and python_full_version >= "3.7.0"
 executing==0.8.2; python_version >= "3.8"
@@ -74,26 +74,26 @@ grpcio==1.43.0; python_full_version >= "3.7.1" and python_full_version < "4.0.0"
 hijri-converter==2.2.2; python_version >= "3.6"
 holidays==0.11.3.1; python_version >= "3.6"
 identify==2.4.6; python_version >= "3.7" and python_full_version >= "3.6.1"
-idna==3.3; python_full_version >= "3.6.2" and python_version >= "3.7"
+idna==3.3; python_full_version >= "3.7.1" and python_version >= "3.8" and python_version < "4.0" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 imagesize==1.3.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7"
 inflection==0.5.1; python_version >= "3.6"
 iniconfig==1.1.1; python_version >= "3.7"
 investpy==1.0.8; python_version >= "3.7"
 ipykernel==6.7.0; python_version >= "3.7"
 ipympl==0.8.7
-ipython-genutils==0.2.0; python_version >= "3.7"
+ipython-genutils==0.2.0; python_full_version >= "3.7.0" and python_version >= "3.7"
 ipython==8.0.1; python_version >= "3.8"
 ipywidgets==7.6.5
 iso8601==0.1.16
 isort==5.10.1; python_full_version >= "3.6.2" and python_version < "4.0"
 jedi==0.18.1; python_version >= "3.8"
 jinja2==3.0.3; python_version >= "3.7"
-joblib==1.1.0; python_version >= "3.7"
+joblib==1.1.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 json5==0.9.6; python_version >= "3.6"
 jsonschema==3.2.0
 jupyter-client==7.1.2; python_full_version >= "3.7.0" and python_version >= "3.7"
 jupyter-console==6.4.0; python_version >= "3.6"
-jupyter-core==4.9.1; python_full_version >= "3.6.1" and python_version >= "3.7"
+jupyter-core==4.9.1; python_full_version >= "3.7.0" and python_version >= "3.7"
 jupyter-server==1.13.4; python_version >= "3.7"
 jupyter==1.0.0
 jupyterlab-pygments==0.1.2; python_version >= "3.7"
@@ -106,7 +106,7 @@ lazy-object-proxy==1.7.1; python_version >= "3.6" and python_full_version >= "3.
 lxml==4.7.1; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 m2r2==0.2.8; python_version >= "3.7"
 markdown-it-py==1.1.0; python_version >= "3.6" and python_version < "4.0"
-markupsafe==2.0.1; python_version >= "3.6"
+markupsafe==2.0.1; python_version >= "3.7"
 matplotlib-inline==0.1.3; python_version >= "3.8"
 matplotlib==3.5.1; python_version >= "3.7"
 mccabe==0.6.1; python_full_version >= "3.6.2"
@@ -160,11 +160,11 @@ protobuf==3.19.4; python_full_version >= "3.7.1" and python_full_version < "4.0.
 psaw==0.0.12; python_version >= "3"
 ptyprocess==0.7.0; os_name != "nt" and python_version >= "3.8" and sys_platform != "win32"
 pure-eval==0.2.2; python_version >= "3.8"
-py==1.11.0; python_version >= "3.7" and python_full_version < "3.0.0" and implementation_name == "pypy" or python_full_version >= "3.5.0" and python_version >= "3.7" and implementation_name == "pypy"
+py==1.11.0; python_full_version >= "3.7.0" and python_version >= "3.7" and implementation_name == "pypy"
 pyally==1.1.2
 pycodestyle==2.7.0; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pycoingecko==2.2.0
-pycparser==2.21; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
+pycparser==2.21; implementation_name == "pypy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 pyex==0.5.0
 pyflakes==2.3.1; python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.5.0"
 pygments==2.11.2; python_version >= "3.5"
@@ -185,16 +185,16 @@ pytest-recording==0.12.0; python_version >= "3.5"
 pytest==6.2.5; python_version >= "3.6"
 python-binance==1.0.15
 python-coinmarketcap==0.2
-python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
+python-dateutil==2.8.2; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5")
 python-dotenv==0.19.2; python_version >= "3.5"
 pytrends==4.7.3
 pytz-deprecation-shim==0.1.0.post0; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.6"
-pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
+pytz==2021.3; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.7")
 pyupgrade==2.31.0; python_full_version >= "3.6.1"
-pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.6"
+pywin32==303; sys_platform == "win32" and platform_python_implementation != "PyPy" and python_version >= "3.7" and python_full_version >= "3.7.0"
 pywinpty==2.0.1; os_name == "nt" and python_version >= "3.7"
 pyyaml==6.0; python_version >= "3.7" and python_full_version >= "3.6.1"
-pyzmq==22.3.0; python_full_version >= "3.6.1" and python_version >= "3.7"
+pyzmq==22.3.0; python_full_version >= "3.7.0" and python_version >= "3.7"
 qdldl==0.1.5.post0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 qtconsole==5.2.2; python_version >= "3.6"
 qtpy==2.0.0; python_version >= "3.6"
@@ -207,7 +207,7 @@ requests==2.27.1; (python_version >= "2.7" and python_full_version < "3.0.0") or
 rich==10.16.2; python_full_version >= "3.6.2" and python_full_version < "4.0.0"
 robin-stocks==2.1.0; python_version >= "3"
 scikit-learn==1.0.2; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
-scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0")
+scipy==1.7.3; python_version >= "3.7" and python_version < "3.11" and python_full_version >= "3.6.1" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 screeninfo==0.6.7
 scs==3.1.0; python_full_version >= "3.6.1" and python_full_version < "4.0.0" and python_version >= "3.6"
 seaborn==0.11.2; python_version >= "3.6"
@@ -215,7 +215,7 @@ selenium==3.141.0
 send2trash==1.8.0; python_version >= "3.7"
 sentiment-investor==2.1.0; python_version >= "3.8" and python_version < "4.0"
 setuptools-scm==6.4.2; python_version >= "3.7"
-six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.6" and python_full_version < "4.0.0" and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
+six==1.16.0; python_full_version >= "3.7.1" and python_version >= "3.7" and python_full_version < "4.0.0" and (python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.6") and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0") and (python_version >= "3.5" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.5") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7") and (python_version >= "3.8" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.8")
 smmap==5.0.0; python_version >= "3.7"
 sniffio==1.2.0; python_full_version >= "3.6.2" and python_version >= "3.7"
 snowballstemmer==2.2.0; python_version >= "3.7"
@@ -240,12 +240,12 @@ terminado==0.13.1; python_version >= "3.7"
 testpath==0.5.0; python_version >= "3.7"
 textwrap3==0.9.2; python_version >= "3.6"
 thepassiveinvestor==1.0.10
-threadpoolctl==3.0.0; python_version >= "3.7"
+threadpoolctl==3.0.0; python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7"
 tokenize-rt==4.2.1; python_full_version >= "3.6.1"
 toml==0.10.2; python_full_version >= "3.6.2" and python_version >= "3.6" and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.3.0" and python_version >= "3.7")
 tomli==1.2.3; python_version >= "3.8" and python_full_version >= "3.6.2"
 toolz==0.11.2; python_version >= "3.7" and python_full_version >= "3.7.0"
-tornado==6.1; python_full_version >= "3.6.1" and python_version >= "3.7"
+tornado==6.1; python_full_version >= "3.7.0" and python_version >= "3.7"
 tqdm==4.62.3; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.4.0" and python_version >= "3.6"
 tradingview-ta==3.2.10; python_version >= "3.6"
 traitlets==5.1.1; python_full_version >= "3.7.0" and python_version >= "3.8"
@@ -261,14 +261,14 @@ tzlocal==4.1; python_version >= "3.6"
 ujson==5.1.0; python_version >= "3.7"
 unidecode==1.3.2; python_version >= "3.7"
 update-checker==0.18.0; python_version >= "3.6" and python_version < "4.0"
-urllib3==1.26.8; python_version >= "3.6" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version < "4" and python_version >= "3.6"
+urllib3==1.26.8; python_full_version >= "3.7.1" and python_version < "4" and python_version >= "3.8" and python_full_version < "4.0.0" and (python_version >= "2.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0") and (python_version >= "3.7" and python_full_version < "3.0.0" or python_full_version >= "3.6.0" and python_version >= "3.7")
 user-agent==0.1.10
 vadersentiment==3.3.2
 valinvest==0.0.2; python_version >= "3.6"
 vcrpy==4.1.1; python_version >= "3.5"
 virtualenv==20.13.0; python_full_version >= "3.6.1"
 voila==0.3.1; python_version >= "3.7"
-wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.6"
+wcwidth==0.2.5; python_full_version >= "3.6.2" and python_version >= "3.8"
 webencodings==0.5.1; python_version >= "3.7"
 websocket-client==1.2.3; python_version >= "3.8" and python_version < "4.0"
 websockets==9.1; python_full_version >= "3.6.1" and python_version >= "3.7"


### PR DESCRIPTION
Bumps tensorflow from 2.7.0 to 2.7.1 based on dependabot's recommendations.