### PR TITLE
Fix plot stocks/options/grhist

### DIFF
--- a/gamestonk_terminal/stocks/options/syncretism_view.py
+++ b/gamestonk_terminal/stocks/options/syncretism_view.py
@@ -158,19 +158,20 @@ def view_historical_greeks(
         (ax,) = external_axes
 
     # Theo I am sorry but I don't know how to get different line colors and move the delta
-    im1 = ax.plot(df.index, df[greek], label=greek.title())
+    im1 = ax.plot(df.index, df[greek], label=greek.title(), color=theme.up_color)
     ax.set_ylabel(greek)
     ax1 = ax.twinx()
-    im2 = ax1.plot(df.index, df.price, label="Stock Price")
+    im2 = ax1.plot(df.index, df.price, label="Stock Price", color=theme.down_color)
     ax1.set_ylabel(f"{ticker} Price")
     ax.set_title(
-        f"{greek} historical for {ticker.upper()} {strike} {['Call','Put'][put]}"
+        f"{(greek).capitalize()} historical for {ticker.upper()} {strike} {['Call','Put'][put]}"
     )
-
+    ax.set_xlim(df.index[0], df.index[-1])
     ims = im1 + im2
     labels = [lab.get_label() for lab in ims]
+
     ax.legend(ims, labels, loc=0)
-    theme.style_primary_axis(ax)
+    theme.style_twin_axes(ax, ax1)
 
     if not external_axes:
         theme.visualize_output()


### PR DESCRIPTION
Fixes #1426 

<img width="774" alt="Pasted Graphic 2" src="https://user-images.githubusercontent.com/40023817/156389614-1ad5407d-4e8d-4201-b7dc-c25125b837e7.png">

- Change colors of two lines so they are distinctively different
- Set limit for x axis
- Fix y labels crowding the scale

# Description

- [ ] Summary of the change / bug fix.
- [ ] Link # issue, if applicable.
- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context. 
- [ ] List any dependencies that are required for this change.


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [ ] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
