### PR TITLE
Fix bug "Warning: Input is not a terminal" when using API

### DIFF
--- a/gamestonk_terminal/stocks/dark_pool_shorts/__init__.py
+++ b/gamestonk_terminal/stocks/dark_pool_shorts/__init__.py
@@ -1,1 +1,0 @@
-from . import dps_controller  # noqa: F401


### PR DESCRIPTION
@piiq noticed this warning when using the API in the Jupyter notebook.

This is due to a controller module being imported to the API wrapper.

<img width="610" alt="image" src="https://user-images.githubusercontent.com/40023817/156546944-a8bcc7f4-afdb-4dfa-bbbe-556429ffeffd.png">


# Description

- [ ] Summary of the change / bug fix.
- [ ] Link # issue, if applicable.
- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context. 
- [ ] List any dependencies that are required for this change.


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [ ] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
