### PR TITLE
Fix bug setting CMC api key not working under keys menu

### DIFF
--- a/gamestonk_terminal/keys_controller.py
+++ b/gamestonk_terminal/keys_controller.py
@@ -264,8 +264,9 @@ class KeysController(BaseController):
             self.key_dict["COINMARKETCAP"] = "not defined"
         else:
             cmc = CoinMarketCapAPI(cfg.API_CMC_KEY)
+
             try:
-                cmc.exchange_info()
+                cmc.cryptocurrency_map()
                 logger.info("Coinmarketcap key defined, test passed")
                 self.key_dict["COINMARKETCAP"] = "defined, test passed"
             except CoinMarketCapAPIError:


### PR DESCRIPTION
Fixed #1340 

- It's currently throwing another error, which we then thought due to Invalid API Key

<img width="669" alt="image" src="https://user-images.githubusercontent.com/40023817/156567875-46d59de9-30f3-4d0d-9deb-dcb47761eb95.png">


# Description

- [ ] Summary of the change / bug fix.
- [ ] Link # issue, if applicable.
- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context. 
- [ ] List any dependencies that are required for this change.


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [ ] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [ ] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [ ] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
