### PR TITLE
Added dark mode

### DIFF
--- a/gamestonk_terminal/jupyter/dashboards/dashboards_controller.py
+++ b/gamestonk_terminal/jupyter/dashboards/dashboards_controller.py
@@ -98,6 +98,14 @@ def create_call(other_args: List[str], name: str, filename: str = None) -> None:
         dest="input",
         help="Skips confirmation to run server.",
     )
+    parser.add_argument(
+        "-d",
+        "--dark",
+        action="store_true",
+        default=False,
+        dest="dark",
+        help="Whether to show voila in dark mode",
+    )
 
     ns_parser = parse_known_args_and_warn(parser, other_args)
 
@@ -111,9 +119,12 @@ def create_call(other_args: List[str], name: str, filename: str = None) -> None:
                 f"Warning: opens a port on your computer to run a {cmd} server."
             )
             response = input("Would you like us to run the server for you? y/n\n")
+        args = ""
+        if ns_parser.dark and not ns_parser.jupyter:
+            args += "--theme=dark"
         if ns_parser.input or response.lower() == "y":
             subprocess.Popen(
-                f"{cmd} {file}",
+                f"{cmd} {file} {args}",
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
                 shell=True,

--- a/website/content/jupyter/dashboards/chains/_index.md
+++ b/website/content/jupyter/dashboards/chains/_index.md
@@ -7,6 +7,7 @@ Opens a voila dashboard showing option chain information for a given ticker and 
 ```
 optional arguments:
   -j, --jupyter         opens in jupyterlab instead of voila (default: False)
+  -d, --dark            runs voila in dark mode (default: False)
   -n, --no-input        does not ask the user if it can open a server (default: False)
   -h, --help            show this help message
 ```

--- a/website/content/jupyter/dashboards/correlations/_index.md
+++ b/website/content/jupyter/dashboards/correlations/_index.md
@@ -7,6 +7,7 @@ Opens a voila dashboard showing the correlations between stocks
 ```
 optional arguments:
   -j, --jupyter         opens in jupyterlab instead of voila (default: False)
+  -d, --dark            runs voila in dark mode (default: False)
   -n, --no-input        does not ask the user if it can open a server (default: False)
   -h, --help            show this help message
 ```

--- a/website/content/jupyter/dashboards/shortdata/_index.md
+++ b/website/content/jupyter/dashboards/shortdata/_index.md
@@ -7,6 +7,7 @@ Shows shortdata dashboard
 ```
 optional arguments:
   -j, --jupyter         opens in jupyterlab instead of voila (default: False)
+  -d, --dark            runs voila in dark mode (default: False)
   -n, --no-input        does not ask the user if it can open a server (default: False)
-  -h, --help            show this help message
+  -h, --help            show this  (help message
 ```

--- a/website/content/jupyter/dashboards/stocks/_index.md
+++ b/website/content/jupyter/dashboards/stocks/_index.md
@@ -7,6 +7,7 @@ Opens a voila dashboard showing historical data for stocks
 ```
 optional arguments:
   -j, --jupyter         opens in jupyterlab instead of voila (default: False)
+  -d, --dark            runs voila in dark mode (default: False)
   -n, --no-input        does not ask the user if it can open a server (default: False)
   -h, --help            show this help message
 ```

--- a/website/content/jupyter/dashboards/vsurf/_index.md
+++ b/website/content/jupyter/dashboards/vsurf/_index.md
@@ -7,6 +7,7 @@ Shows the volatility surface for options
 ```
 optional arguments:
   -j, --jupyter         opens in jupyterlab instead of voila (default: False)
+  -d, --dark            runs voila in dark mode (default: False)
   -n, --no-input        does not ask the user if it can open a server (default: False)
   -h, --help            show this help message
 ```


### PR DESCRIPTION
# Description

Added a dark mode. Does not always look great, but that is something we can address in the future. For now this gives users an easy way to interact with voila's --theme=dark argument.


# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [x] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
