### PR TITLE
fix no normalization in historical comparison analysis

### DIFF
--- a/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
+++ b/gamestonk_terminal/stocks/comparison_analysis/ca_controller.py
@@ -525,7 +525,7 @@ class ComparisonAnalysisController(BaseController):
         parser.add_argument(
             "-n",
             "--no-scale",
-            action="store_false",
+            action="store_true",
             dest="no_scale",
             default=False,
             help="Flag to not put all prices on same 0-1 scale",

--- a/tests/gamestonk_terminal/stocks/comparison_analysis/test_ca_controller.py
+++ b/tests/gamestonk_terminal/stocks/comparison_analysis/test_ca_controller.py
@@ -241,7 +241,7 @@ def test_call_func_expect_queue(expected_queue, queue, func):
                 similar_tickers=["MOCK_SIMILAR_1", "MOCK_SIMILAR_2"],
                 start="2020-12-01",
                 candle_type="h",
-                normalize=True,
+                normalize=False,
                 export="csv",
             ),
         ),


### PR DESCRIPTION
Very easy fix.

The flag wasn't working properly because of the argparse argument used.