### PR TITLE
[Bug] Fixes axis in gdapps command

### DIFF
--- a/gamestonk_terminal/cryptocurrency/defi/llama_view.py
+++ b/gamestonk_terminal/cryptocurrency/defi/llama_view.py
@@ -71,9 +71,9 @@ def display_grouped_defi_protocols(
             color=next(colors),
         )
 
-    ax.set_ylabel("Total Value Locked ($)")
-    ax.set_xlabel("dApp name")
-    ax.get_yaxis().set_major_formatter(
+    ax.set_xlabel("Total Value Locked ($)")
+    ax.set_ylabel("Decentralized Application Name")
+    ax.get_xaxis().set_major_formatter(
         ticker.FuncFormatter(lambda x, _: lambda_long_number_format(x))
     )
 


### PR DESCRIPTION
# Description
Axis on `gdapps` commands are switched:
<img width="1388" alt="image" src="https://user-images.githubusercontent.com/43375532/157860059-3bf54e33-16a7-42fd-a18d-2fe51679ef6c.png">

PR fixes this by switching Y axis with X axis:
<img width="1395" alt="image" src="https://user-images.githubusercontent.com/43375532/157860012-a0e427e1-219f-43f1-bf07-3196da9ae764.png">



# How has this been tested?

* Please describe the tests that you ran to verify your changes. 
* Provide instructions so we can reproduce. 
* Please also list any relevant details for your test configuration.


# Checklist:

- [x] Update [our Hugo documentation](https://gamestonkterminal.github.io/GamestonkTerminal/) following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/website).
- [x] Update our tests following [these guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/tests).
- [x] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/GamestonkTerminal/GamestonkTerminal/blob/main/CONTRIBUTING.md).
- [x] If a feature was added make sure to add it to the corresponding [scripts file](https://github.com/GamestonkTerminal/GamestonkTerminal/tree/main/scripts).


# Others
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] My code passes all the checks pylint, flake8, black, ... To speed up development you should run `pre-commit install`.
- [x] New and existing unit tests pass locally with my changes. You can test this locally using `pytest tests/...`.
