### PR TITLE
Add execute routines command to main menu

### DIFF
--- a/gamestonk_terminal/alternative/covid/covid_view.py
+++ b/gamestonk_terminal/alternative/covid/covid_view.py
@@ -143,7 +143,7 @@ def display_covid_stat(
     else:
         if len(external_axes) != 1:
             logger.error("Expected list of one axis item.")
-            console.print("[red]Expected list of 1 axis item./n[/red]")
+            console.print("[red]Expected list of 1 axis item.\n[/red]")
             return
         (ax,) = external_axes
 

--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -60,6 +60,26 @@ def set_command_location(cmd_loc: str):
     command_location = cmd_loc
 
 
+def check_path(path: str) -> str:
+    """Check that path file exists
+
+    Parameters
+    ----------
+    path: str
+        path of file
+
+    Returns
+    -------
+    str:
+        Ratio of similarity between two strings
+    """
+    if os.path.isfile(path):
+        return path
+    logger.error("Expected list of one axis item.")
+    console.print("The path file provided does not exist.\n[/red]")
+    return ""
+
+
 def log_and_raise(error: Union[argparse.ArgumentTypeError, ValueError]) -> None:
     logger.error(str(error))
     raise error


### PR DESCRIPTION
The `exe` command is able to run:
* exe routines/example_with_inputs.gst -i tsla,fb,goog
* exe example_with_inputs.gst -i tsla,fb,goog
* exe routines/example.gst
* exe example.gst

<img width="1788" alt="routines" src="https://user-images.githubusercontent.com/25267873/158277119-77286328-7aa1-46e3-9608-8e5e15f6a58b.png">

@Chavithra @LBolte29 do you want to tackle the logging on top of this command? Not sure how you want to tackle it :)