### PR TITLE
Customisable export

### DIFF
--- a/gamestonk_terminal/feature_flags.py
+++ b/gamestonk_terminal/feature_flags.py
@@ -57,3 +57,6 @@ ENABLE_RICH_PANEL = strtobool(os.getenv("GTFF_ENABLE_RICH_PANEL", "True"))
 
 # Check API KEYS before running a command
 ENABLE_CHECK_API = strtobool(os.getenv("GTFF_ENABLE_CHECK_API", "True"))
+
+# Provide export folder path. If empty that means default.
+EXPORT_FOLDER_PATH = os.getenv("GTFF_EXPORT_FOLDER_PATH", "")

--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -14,7 +14,7 @@ import pytz
 import pandas as pd
 from rich.table import Table
 import iso8601
-
+import dotenv
 import matplotlib
 import matplotlib.pyplot as plt
 from holidays import US as us_holidays
@@ -45,8 +45,6 @@ MENU_RESET = 2
 
 # Command location path to be shown in the figures depending on watermark flag
 command_location = ""
-# Folder to export data to
-export_folder = ""
 
 
 # pylint: disable=global-statement
@@ -63,27 +61,19 @@ def set_command_location(cmd_loc: str):
 
 
 # pylint: disable=global-statement
-def set_export_folder(path_folder: str):
+def set_export_folder(env_file: str = ".env", path_folder: str = ""):
     """Set export folder location
 
     Parameters
     ----------
+    env_file : str
+        Env file to be updated
     path_folder: str
         Path folder location
     """
-    global export_folder
-    export_folder = path_folder
-
-
-def get_export_folder() -> str:
-    """Set export folder location
-
-    Returns
-    ----------
-    export_folder: str
-        Path to folder location to export data
-    """
-    return export_folder
+    os.environ["GTFF_EXPORT_FOLDER_PATH"] = path_folder
+    dotenv.set_key(env_file, "GTFF_EXPORT_FOLDER_PATH", path_folder)
+    gtff.EXPORT_FOLDER_PATH = path_folder
 
 
 def check_path(path: str) -> str:
@@ -1109,11 +1099,11 @@ def export_data(
     if export_type:
         now = datetime.now()
 
-        if export_folder:
+        if gtff.EXPORT_FOLDER_PATH:
             path_cmd = dir_path.split("gamestonk_terminal/")[1].replace("/", "_")
 
             full_path = os.path.join(
-                export_folder,
+                gtff.EXPORT_FOLDER_PATH,
                 f"{now.strftime('%Y%m%d_%H%M%S')}_{path_cmd}_{func_name}",
             )
         else:

--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -45,6 +45,8 @@ MENU_RESET = 2
 
 # Command location path to be shown in the figures depending on watermark flag
 command_location = ""
+# Folder to export data to
+export_folder = ""
 
 
 # pylint: disable=global-statement
@@ -58,6 +60,30 @@ def set_command_location(cmd_loc: str):
     """
     global command_location
     command_location = cmd_loc
+
+
+# pylint: disable=global-statement
+def set_export_folder(path_folder: str):
+    """Set export folder location
+
+    Parameters
+    ----------
+    path_folder: str
+        Path folder location
+    """
+    global export_folder
+    export_folder = path_folder
+
+
+def get_export_folder() -> str:
+    """Set export folder location
+
+    Returns
+    ----------
+    export_folder: str
+        Path to folder location to export data
+    """
+    return export_folder
 
 
 def check_path(path: str) -> str:
@@ -1081,15 +1107,23 @@ def export_data(
         Dataframe of data to save
     """
     if export_type:
-        export_dir = dir_path.replace("gamestonk_terminal", "exports")
-
         now = datetime.now()
-        full_path = os.path.abspath(
-            os.path.join(
-                export_dir,
-                f"{func_name}_{now.strftime('%Y%m%d_%H%M%S')}",
+
+        if export_folder:
+            path_cmd = dir_path.split("gamestonk_terminal/")[1].replace("/", "_")
+
+            full_path = os.path.join(
+                export_folder,
+                f"{now.strftime('%Y%m%d_%H%M%S')}_{path_cmd}_{func_name}",
             )
-        )
+        else:
+            export_dir = dir_path.replace("gamestonk_terminal", "exports")
+            full_path = os.path.abspath(
+                os.path.join(
+                    export_dir,
+                    f"{func_name}_{now.strftime('%Y%m%d_%H%M%S')}",
+                )
+            )
 
         if "," not in export_type:
             export_type += ","

--- a/gamestonk_terminal/keys_controller.py
+++ b/gamestonk_terminal/keys_controller.py
@@ -332,19 +332,20 @@ class KeysController(BaseController):
             logger.info("Reddit key not defined")
             self.key_dict["REDDIT"] = "not defined"
         else:
-            praw_api = praw.Reddit(
-                client_id=cfg.API_REDDIT_CLIENT_ID,
-                client_secret=cfg.API_REDDIT_CLIENT_SECRET,
-                username=cfg.API_REDDIT_USERNAME,
-                user_agent=cfg.API_REDDIT_USER_AGENT,
-                password=cfg.API_REDDIT_PASSWORD,
-            )
 
             try:
+                praw_api = praw.Reddit(
+                    client_id=cfg.API_REDDIT_CLIENT_ID,
+                    client_secret=cfg.API_REDDIT_CLIENT_SECRET,
+                    username=cfg.API_REDDIT_USERNAME,
+                    user_agent=cfg.API_REDDIT_USER_AGENT,
+                    password=cfg.API_REDDIT_PASSWORD,
+                )
+
                 praw_api.user.me()
                 logger.info("Reddit key defined, test passed")
                 self.key_dict["REDDIT"] = "defined, test passed"
-            except ResponseException:
+            except (Exception, ResponseException):
                 logger.warning("Reddit key defined, test passed")
                 self.key_dict["REDDIT"] = "defined, test failed"
 
@@ -737,6 +738,12 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print(
+                "For your API Key, visit: https://www.alphavantage.co/support/#api-key\n"
+            )
+            return
+
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -762,6 +769,12 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print(
+                "For your API Key, visit: https://financialmodelingprep.com\n"
+            )
+            return
+
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -789,6 +802,10 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://www.quandl.com\n")
+            return
+
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -814,6 +831,10 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://polygon.io\n")
+            return
+
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -839,6 +860,10 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://fred.stlouisfed.org\n")
+            return
+
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -864,6 +889,10 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://newsapi.org\n")
+            return
+
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -889,6 +918,10 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://developer.tradier.com\n")
+            return
+
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -914,6 +947,9 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://coinmarketcap.com\n")
+            return
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -939,6 +975,9 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://finnhub.io\n")
+            return
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -964,6 +1003,9 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://iexcloud.io\n")
+            return
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -1017,6 +1059,9 @@ class KeysController(BaseController):
             dest="user_agent",
             help="User agent",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://www.reddit.com\n")
+            return
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if ns_parser:
             os.environ["GT_API_REDDIT_CLIENT_ID"] = ns_parser.client_id
@@ -1077,6 +1122,9 @@ class KeysController(BaseController):
             dest="bearer_token",
             help="Bearer token",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://developer.twitter.com\n")
+            return
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if ns_parser:
             os.environ["GT_API_TWITTER_KEY"] = ns_parser.key
@@ -1120,6 +1168,9 @@ class KeysController(BaseController):
             dest="password",
             help="password",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://robinhood.com/us/en/\n")
+            return
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if ns_parser:
             os.environ["GT_RH_USERNAME"] = ns_parser.username
@@ -1162,6 +1213,9 @@ class KeysController(BaseController):
             dest="secret",
             help="TOPT Secret",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://www.degiro.fr\n")
+            return
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if ns_parser:
             os.environ["GT_DG_USERNAME"] = ns_parser.username
@@ -1208,6 +1262,9 @@ class KeysController(BaseController):
             dest="account_type",
             help="account type",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://developer.oanda.com\n")
+            return
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if ns_parser:
             os.environ["GT_OANDA_ACCOUNT"] = ns_parser.account
@@ -1249,6 +1306,9 @@ class KeysController(BaseController):
             dest="secret_key",
             help="Secret key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://binance.com\n")
+            return
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if ns_parser:
             os.environ["GT_API_BINANCE_KEY"] = ns_parser.key
@@ -1277,6 +1337,9 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://bitquery.io/\n")
+            return
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -1303,6 +1366,9 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://sentimentinvestor.com\n")
+            return
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -1345,6 +1411,9 @@ class KeysController(BaseController):
             dest="passphrase",
             help="Passphrase",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://docs.pro.coinbase.com/\n")
+            return
         ns_parser = parse_known_args_and_warn(parser, other_args)
         if ns_parser:
             os.environ["GT_API_COINBASE_KEY"] = ns_parser.key
@@ -1381,6 +1450,9 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print("For your API Key, visit: https://docs.whale-alert.io/\n")
+            return
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -1407,6 +1479,11 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print(
+                "For your API Key, visit: https://docs.glassnode.com/basic-api/api-key#how-to-get-an-api-key/\n"
+            )
+            return
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -1433,6 +1510,11 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print(
+                "For your API Key, visit: https://coinglass.github.io/API-Reference/#api-key\n"
+            )
+            return
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -1459,6 +1541,11 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print(
+                "For your API Key, visit: https://cryptopanic.com/developers/api/\n"
+            )
+            return
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -1485,6 +1572,11 @@ class KeysController(BaseController):
             dest="key",
             help="key",
         )
+        if not other_args:
+            console.print(
+                "For your API Key, visit: https://github.com/EverexIO/Ethplorer/wiki/Ethplorer-API\n"
+            )
+            return
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-k")
         ns_parser = parse_known_args_and_warn(parser, other_args)
@@ -1517,7 +1609,9 @@ class KeysController(BaseController):
             dest="token",
             help="Token",
         )
-
+        if not other_args:
+            console.print("For your API Key, visit: https://www.smartstake.io\n")
+            return
         ns_parser = parse_known_args_and_warn(parser, other_args)
 
         if ns_parser:
@@ -1530,11 +1624,3 @@ class KeysController(BaseController):
             cfg.API_SMARTSTAKE_KEY = ns_parser.key
 
             self.check_smartstake_key(show_output=True)
-
-        ns_parser = parse_known_args_and_warn(parser, other_args)
-        if ns_parser:
-            os.environ["GT_API_ETHPLORER_KEY"] = ns_parser.key
-            dotenv.set_key(self.env_file, "GT_API_ETHPLORER_KEY", ns_parser.key)
-            cfg.API_ETHPLORER_KEY = ns_parser.key
-
-            self.check_ethplorer_key(show_output=True)

--- a/gamestonk_terminal/keys_controller.py
+++ b/gamestonk_terminal/keys_controller.py
@@ -4,7 +4,6 @@ __docformat__ = "numpy"
 import argparse
 import logging
 import os
-from pathlib import Path
 from typing import Dict, List
 
 import dotenv
@@ -69,18 +68,13 @@ class KeysController(BaseController):
     PATH = "/keys/"
     key_dict: Dict = {}
     cfg_dict: Dict = {}
-    env_file = ".env"
-    env_files = [f for f in os.listdir() if f.endswith(".env")]
-    if env_files:
-        env_file = env_files[0]
-        dotenv.load_dotenv(env_file)
-    else:
-        # create env file
-        Path(".env")
 
-    def __init__(self, queue: List[str] = None, menu_usage: bool = True):
+    def __init__(
+        self, queue: List[str] = None, menu_usage: bool = True, env_file: str = ".env"
+    ):
         """Constructor"""
         super().__init__(queue)
+        self.env_file = env_file
         if menu_usage:
             self.check_keys_status()
 
@@ -481,14 +475,18 @@ class KeysController(BaseController):
             logger.info("Sentiment Investor key not defined")
             self.key_dict["SENTIMENT_INVESTOR"] = "not defined"
         else:
-            account = requests.get(
-                f"https://api.sentimentinvestor.com/v1/trending"
-                f"?token={cfg.API_SENTIMENTINVESTOR_TOKEN}"
-            )
-            if account.ok and account.json().get("success", False):
-                logger.info("Sentiment Investor key defined, test passed")
-                self.key_dict["SENTIMENT_INVESTOR"] = "defined, test passed"
-            else:
+            try:
+                account = requests.get(
+                    f"https://api.sentimentinvestor.com/v1/trending"
+                    f"?token={cfg.API_SENTIMENTINVESTOR_TOKEN}"
+                )
+                if account.ok and account.json().get("success", False):
+                    logger.info("Sentiment Investor key defined, test passed")
+                    self.key_dict["SENTIMENT_INVESTOR"] = "defined, test passed"
+                else:
+                    logger.warning("Sentiment Investor key defined, test failed")
+                    self.key_dict["SENTIMENT_INVESTOR"] = "defined, test unsuccessful"
+            except Exception:
                 logger.warning("Sentiment Investor key defined, test failed")
                 self.key_dict["SENTIMENT_INVESTOR"] = "defined, test unsuccessful"
 

--- a/gamestonk_terminal/stocks/due_diligence/dd_controller.py
+++ b/gamestonk_terminal/stocks/due_diligence/dd_controller.py
@@ -11,6 +11,7 @@ from prompt_toolkit.completion import NestedCompleter
 from gamestonk_terminal import feature_flags as gtff
 from gamestonk_terminal.decorators import log_start_end
 from gamestonk_terminal.helper_funcs import (
+    EXPORT_BOTH_RAW_DATA_AND_FIGURES,
     EXPORT_ONLY_RAW_DATA_ALLOWED,
     check_positive,
     parse_known_args_and_warn,
@@ -146,7 +147,7 @@ class DueDiligenceController(StockBaseController):
         if other_args and "-" not in other_args[0][0]:
             other_args.insert(0, "-l")
         ns_parser = parse_known_args_and_warn(
-            parser, other_args, EXPORT_ONLY_RAW_DATA_ALLOWED
+            parser, other_args, EXPORT_BOTH_RAW_DATA_AND_FIGURES
         )
         if ns_parser:
             business_insider_view.price_target_from_analysts(

--- a/gamestonk_terminal/terminal_helper.py
+++ b/gamestonk_terminal/terminal_helper.py
@@ -11,7 +11,6 @@ import sys
 from datetime import datetime
 from typing import List
 import ascii_magic
-
 import matplotlib.pyplot as plt
 
 from gamestonk_terminal import feature_flags as gtff

--- a/terminal.py
+++ b/terminal.py
@@ -403,9 +403,9 @@ class TerminalController(BaseController):
 
 
 # pylint: disable=global-statement
-def terminal(jobs_cmds: List[str] = None):
+def terminal(jobs_cmds: List[str] = None, appName: str = "gst"):
     """Terminal Menu"""
-    setup_logging("gst")
+    setup_logging(appName)
     logger.info("START")
     logger.info("Python: %s", platform.python_version())
     logger.info("OS: %s", platform.system())

--- a/terminal.py
+++ b/terminal.py
@@ -263,7 +263,9 @@ class TerminalController(BaseController):
                     success_export = True
                 else:
                     # If the path selected does not start from the user root, give relative location from terminal root
-                    if export_path[0] != "/":
+                    if export_path[0] == "~":
+                        export_path = export_path.replace("~", os.environ["HOME"])
+                    elif export_path[0] != "/":
                         export_path = os.path.join(base_path, export_path)
 
                     # Check if the directory exists

--- a/terminal.py
+++ b/terminal.py
@@ -243,6 +243,7 @@ class TerminalController(BaseController):
             if other_args:
                 export_path = ""
             else:
+                # Re-add the initial slash for an absolute directory provided
                 export_path = "/"
 
             other_args += self.queue
@@ -254,7 +255,6 @@ class TerminalController(BaseController):
             default_path = os.path.join(base_path, "exports")
 
             success_export = False
-
             while not success_export:
                 if export_path.upper() == "DEFAULT":
                     console.print(
@@ -304,10 +304,6 @@ class TerminalController(BaseController):
                                 f"[yellow]Export data to keep being saved in the selected folder: {path_display}[/yellow]"
                             )
                         success_export = True
-
-            # other_args.append(self.queue[0])
-            # self.queue = self.queue[1:]
-            # print("/".join(other_args))
 
         console.print()
 

--- a/terminal.py
+++ b/terminal.py
@@ -9,8 +9,9 @@ import logging
 import argparse
 import platform
 from typing import List
+from pathlib import Path
 import pytz
-
+import dotenv
 
 from prompt_toolkit.completion import NestedCompleter
 from gamestonk_terminal.rich_config import console
@@ -23,12 +24,10 @@ from gamestonk_terminal.helper_funcs import (
     check_path,
     parse_known_args_and_warn,
     set_export_folder,
-    get_export_folder,
 )
 
 from gamestonk_terminal.loggers import setup_logging
 from gamestonk_terminal.menu import session
-
 from gamestonk_terminal.terminal_helper import (
     about_us,
     bootup,
@@ -43,6 +42,8 @@ from gamestonk_terminal.terminal_helper import (
 # pylint: disable=too-many-public-methods,import-outside-toplevel
 
 logger = logging.getLogger(__name__)
+
+env_file = ".env"
 
 
 class TerminalController(BaseController):
@@ -125,7 +126,7 @@ class TerminalController(BaseController):
 >   settings        set feature flags and style charts
 >   keys            set API keys and check their validity[/menu]
 
-[param]Export Folder:[/param] {get_export_folder() if get_export_folder() else 'DEFAULT (folder: exports/)'}
+[param]Export Folder:[/param] {gtff.EXPORT_FOLDER_PATH if gtff.EXPORT_FOLDER_PATH else 'DEFAULT (folder: exports/)'}
 [param]Timezone:     [/param] {get_user_timezone_or_invalid()}
 [menu]
 >   stocks
@@ -150,7 +151,7 @@ class TerminalController(BaseController):
         """Process keys command"""
         from gamestonk_terminal.keys_controller import KeysController
 
-        self.queue = self.load_class(KeysController, self.queue)
+        self.queue = self.load_class(KeysController, self.queue, env_file)
 
     def call_settings(self, _):
         """Process settings command"""
@@ -259,7 +260,7 @@ class TerminalController(BaseController):
                     console.print(
                         f"Export data to be saved in the default folder: '{default_path}'"
                     )
-                    set_export_folder(path_folder="")
+                    set_export_folder(env_file, path_folder="")
                     success_export = True
                 else:
                     # If the path selected does not start from the user root, give relative location from terminal root
@@ -273,7 +274,7 @@ class TerminalController(BaseController):
                         console.print(
                             f"Export data to be saved in the selected folder: '{export_path}'"
                         )
-                        set_export_folder(path_folder=export_path)
+                        set_export_folder(env_file, path_folder=export_path)
                         success_export = True
                     else:
                         console.print(
@@ -291,12 +292,12 @@ class TerminalController(BaseController):
                                 f"[green]Folder '{export_path}' successfully created.[/green]"
                             )
                             print(export_path)
-                            set_export_folder(path_folder=export_path)
+                            set_export_folder(env_file, path_folder=export_path)
                         else:
                             # Do not update export_folder path since we will keep the same as before
                             path_display = (
-                                get_export_folder()
-                                if get_export_folder()
+                                gtff.EXPORT_FOLDER_PATH
+                                if gtff.EXPORT_FOLDER_PATH
                                 else "DEFAULT (folder: exports/)"
                             )
                             console.print(
@@ -401,6 +402,7 @@ class TerminalController(BaseController):
                     self.queue = cmds_with_params.split("/")
 
 
+# pylint: disable=global-statement
 def terminal(jobs_cmds: List[str] = None):
     """Terminal Menu"""
     setup_logging("gst")
@@ -420,6 +422,15 @@ def terminal(jobs_cmds: List[str] = None):
     if not jobs_cmds:
         welcome_message()
         t_controller.print_help()
+
+    env_files = [f for f in os.listdir() if f.endswith(".env")]
+    if env_files:
+        global env_file
+        env_file = env_files[0]
+        dotenv.load_dotenv(env_file)
+    else:
+        # create env file
+        Path(".env")
 
     while ret_code:
         if gtff.ENABLE_QUICK_EXIT:

--- a/terminal.py
+++ b/terminal.py
@@ -287,11 +287,10 @@ class TerminalController(BaseController):
                             ).upper()
 
                         if user_opt == "Y":
-                            os.mkdir(export_path)
+                            os.makedirs(export_path)
                             console.print(
                                 f"[green]Folder '{export_path}' successfully created.[/green]"
                             )
-                            print(export_path)
                             set_export_folder(env_file, path_folder=export_path)
                         else:
                             # Do not update export_folder path since we will keep the same as before


### PR DESCRIPTION
This should allow to export to any folder regardless of it being:
* Relative path to terminal, e.g. routine_monday
* Absolute path to terminal, e.g. /Users/DidierLopes/Documents/GamestonkTerminal/routine_monday
* Path containing environment var, e.g. ~/Documents/GamestonkTerminal/routine_monday

The export folder is then updated as feature flag and will last for next time terminal is booted up.

If the user provides this path, then the commands are saved like this:
`date_time_context_menu_command.TYPE`

if the user doesn't provide path and is default, commands are saved like this:
`exports/context/menu/command_date_time.TYPE`

This is because if a user selects a folder he is interested in having all data in order of creation in the same place.

In a next PR I will add the user selecting the name of the export file.