### PR TITLE
Currencies dashboard

### DIFF
--- a/gamestonk_terminal/helper_funcs.py
+++ b/gamestonk_terminal/helper_funcs.py
@@ -1108,7 +1108,7 @@ def check_file_type_saved(valid_types: List[str] = None):
         Parameters
         ----------
         filenames: str
-            filneames to be saved separated with comma
+            filenames to be saved separated with comma
 
         Returns
         -------

--- a/gamestonk_terminal/jupyter/dashboards/currencies.ipynb
+++ b/gamestonk_terminal/jupyter/dashboards/currencies.ipynb
@@ -1,0 +1,284 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "da655985-c9b7-492e-aefa-fbe3bc1865d5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import sys\n",
+    "import time\n",
+    "from datetime import datetime, timedelta\n",
+    "from typing import Optional\n",
+    "\n",
+    "import ipywidgets as ipw\n",
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib_inline.backend_inline\n",
+    "from ipyflex import FlexLayout\n",
+    "from widget_helpers import price_card, stylesheet\n",
+    "\n",
+    "from gamestonk_terminal import api as gst\n",
+    "\n",
+    "%matplotlib widget\n",
+    "gst.theme.applyMPLstyle()\n",
+    "ipw.HTML(f\"<style>{stylesheet()}</style>\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f5905453-4de6-4f5f-8012-9acdfca50987",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def get_exchange_rate(currency_pair: str) -> str:\n",
+    "    \"\"\"Get exchange rate for a currency pair.\"\"\"\n",
+    "    from_symbol, to_symbol = currency_pair.split(\"/\")\n",
+    "    exchange_data = gst.forex.models.av.get_quote(\n",
+    "        to_symbol=to_symbol, from_symbol=from_symbol\n",
+    "    )\n",
+    "    return exchange_data[\"Realtime Currency Exchange Rate\"][\"5. Exchange Rate\"][:6]\n",
+    "\n",
+    "\n",
+    "def get_candle_widget(\n",
+    "    output: Optional[ipw.Output],\n",
+    "    to_symbol: str,\n",
+    "    from_symbol: str,\n",
+    ") -> ipw.Output:\n",
+    "    \"\"\"Plot a candle chart for a currency pair.\"\"\"\n",
+    "    start_date = datetime.now() - timedelta(days=1)\n",
+    "    start_date = start_date.strftime(\"%Y-%m-%d\")\n",
+    "\n",
+    "    exchange_rate_data = gst.forex.models.av.get_historical(\n",
+    "        to_symbol=to_symbol,\n",
+    "        from_symbol=from_symbol,\n",
+    "        start_date=start_date,\n",
+    "        resolution=\"i\",\n",
+    "        interval=\"15\",\n",
+    "    )\n",
+    "    fig, ax = plt.subplots(1, 1, figsize=(11, 4))\n",
+    "    gst.forex.candle(\n",
+    "        data=exchange_rate_data,\n",
+    "        to_symbol=to_symbol,\n",
+    "        from_symbol=from_symbol,\n",
+    "        external_axes=[ax],\n",
+    "    )\n",
+    "\n",
+    "    ax.set_xlim(0, len(exchange_rate_data.index))\n",
+    "    fig.canvas.header_visible = False\n",
+    "    fig.canvas.footer_visible = False\n",
+    "    with output:\n",
+    "        output.clear_output(True)\n",
+    "        fig.canvas.show()\n",
+    "    return output\n",
+    "\n",
+    "\n",
+    "def on_dropdown_change(change):\n",
+    "    \"\"\"Update charts on change of dropdown selection.\"\"\"\n",
+    "    if change[\"type\"] == \"change\" and change[\"name\"] == \"value\":\n",
+    "        output = ipw.Output()\n",
+    "        get_candle_widget(\n",
+    "            to_symbol=to_widget.value,\n",
+    "            from_symbol=from_widget.value,\n",
+    "        )\n",
+    "        dashboard.children[\"Candle\"] = output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5c768d15-37ad-441b-b069-506c4bdbb9a7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "exchange_rates = {\n",
+    "    \"EUR/USD\": {\"latest\": None, \"previous\": None},\n",
+    "    \"USD/JPY\": {\"latest\": None, \"previous\": None},\n",
+    "    \"GBP/USD\": {\"latest\": None, \"previous\": None},\n",
+    "    \"AUD/USD\": {\"latest\": None, \"previous\": None},\n",
+    "    \"USD/CAD\": {\"latest\": None, \"previous\": None},\n",
+    "    # \"USD/CNY\": {\"latest\": None, \"previous\": None},\n",
+    "    # \"USD/CHF\": {\"latest\": None, \"previous\": None},\n",
+    "    # \"USD/HKD\": {\"latest\": None, \"previous\": None},\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4968ab89-aafe-4234-933c-963bd672715d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def compose_widgets():\n",
+    "    widgets = {}\n",
+    "    for currency_pair in exchange_rates:\n",
+    "        price = exchange_rates[currency_pair][\"latest\"]\n",
+    "        price_color = \"neutral_color\"\n",
+    "        if exchange_rates[currency_pair][\"previous\"] is not None:\n",
+    "            if (\n",
+    "                exchange_rates[currency_pair][\"latest\"]\n",
+    "                > exchange_rates[currency_pair][\"previous\"]\n",
+    "            ):\n",
+    "                price_color = \"up_color\"\n",
+    "            elif (\n",
+    "                exchange_rates[currency_pair][\"latest\"]\n",
+    "                < exchange_rates[currency_pair][\"previous\"]\n",
+    "            ):\n",
+    "                price_color = \"down_color\"\n",
+    "        widgets[currency_pair] = ipw.HTML(\n",
+    "            price_card(ticker=currency_pair, price=price, price_color=price_color)\n",
+    "        )\n",
+    "    return widgets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f35d1500-a411-4cff-94ee-d65d4d1810f9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# for currency_code in rates_to_usd:\n",
+    "#     rates_to_usd[currency_code][\"previous\"] = rates_to_usd[currency_code][\"latest\"]\n",
+    "#     rates_to_usd[currency_code][\"latest\"] = get_rate_against_usd(currency_code)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a72837b-4ddd-4c01-a493-ebb430202cbc",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "widgets = compose_widgets()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c636543c-42fe-4dd6-a900-1552a3c28c7e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "currency_list = gst.forex.models.av.get_currency_list()\n",
+    "from_widget = ipw.Dropdown(\n",
+    "    options=currency_list,\n",
+    "    value=\"EUR\",\n",
+    "    description=\"From:\",\n",
+    "    disabled=False,\n",
+    "    layout=ipw.Layout(margin=\"130\"),\n",
+    ")\n",
+    "to_widget = ipw.Dropdown(\n",
+    "    options=currency_list,\n",
+    "    value=\"USD\",\n",
+    "    description=\"To:\",\n",
+    "    disabled=False,\n",
+    ")\n",
+    "exchange_selection = ipw.VBox([from_widget, to_widget])\n",
+    "\n",
+    "widgets[\"Select\"] = exchange_selection"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9d069845-d622-4878-8b18-b385c6cb7a7f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output = ipw.Output()\n",
+    "output = get_candle_widget(\n",
+    "    output=output,\n",
+    "    to_symbol=to_widget.value,\n",
+    "    from_symbol=from_widget.value,\n",
+    ")\n",
+    "widgets[\"Candle\"] = output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "81c7e5c7-2e52-45ba-bf7d-aa240f95be2d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from_widget.observe(on_dropdown_change)\n",
+    "to_widget.observe(on_dropdown_change)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a0c7d921-e5dc-4ce8-97f1-a59b414a676a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dashboard = FlexLayout(\n",
+    "    layout_config={\"borderLeft\": False, \"borderRight\": False, \"enableSection\": False},\n",
+    "    style={\n",
+    "        \"height\": \"calc(100vh - 80px)\",\n",
+    "        \"backgroundColor\": \"rgb(0 0 0)\",\n",
+    "        \"fontFamily\": \"Consolas\",\n",
+    "        \"fontWeight\": 800,\n",
+    "    },\n",
+    "    header={\n",
+    "        \"title\": \"Currencies\",\n",
+    "        \"style\": {\n",
+    "            \"backgroundColor\": \"rgb(0 0 0)\",\n",
+    "            \"fontWeight\": 400,\n",
+    "            \"fontSize\": \"28px\",\n",
+    "        },\n",
+    "        \"buttons\": [],\n",
+    "    },\n",
+    "    widgets=widgets,\n",
+    "    template=os.path.join(\"widgets\", \"currencies.json\"),\n",
+    "    editable=False,\n",
+    ")\n",
+    "dashboard"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5fedac44-5e09-44f0-bbbe-fbad7c8716cd",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3c850ba2-408b-4061-947e-5a1b8a284d22",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.12"
+  },
+  "voila": {
+   "theme": "dark"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/gamestonk_terminal/jupyter/dashboards/dashboards_controller.py
+++ b/gamestonk_terminal/jupyter/dashboards/dashboards_controller.py
@@ -25,8 +25,15 @@ logger = logging.getLogger(__name__)
 class DashboardsController(BaseController):
     """Dashboards Controller class"""
 
-    CHOICES_COMMANDS = ["stocks", "correlation", "vsurf", "chains", "shortdata"]
-    PATH = "/jupyter/dashboards/"
+    CHOICES_COMMANDS = [
+        "stocks",
+        "correlation",
+        "vsurf",
+        "chains",
+        "shortdata",
+        "currencies",
+    ]
+    PATH = "/jupyter/dashboard/"
 
     def __init__(self, queue: List[str] = None):
         """Constructor"""
@@ -43,7 +50,8 @@ class DashboardsController(BaseController):
    correlation   stock correlations
    vsurf         options volatility surface
    chains        options chain analysis
-   shortdata     finra shortdata analysis[/cmds]
+   shortdata     finra shortdata analysis
+   currencies    forex currency exchange dashboard[/cmds]
         """
         console.print(text=help_text, menu="Jupyter - Dashboards")
 
@@ -64,13 +72,18 @@ class DashboardsController(BaseController):
 
     @log_start_end(log=logger)
     def call_chains(self, other_args: List[str]):
-        """Process vsurf command"""
+        """Process chains command"""
         create_call(other_args, "chains", "")
 
     @log_start_end(log=logger)
     def call_shortdata(self, other_args: List[str]):
-        """Process vsurf command"""
+        """Process shortdata command"""
         create_call(other_args, "shortdata", "")
+
+    @log_start_end(log=logger)
+    def call_currencies(self, other_args: List[str]):
+        """Process currencies command"""
+        create_call(other_args, "currencies", "")
 
 
 def create_call(other_args: List[str], name: str, filename: str = None) -> None:

--- a/gamestonk_terminal/jupyter/dashboards/widget_helpers.py
+++ b/gamestonk_terminal/jupyter/dashboards/widget_helpers.py
@@ -1,0 +1,42 @@
+"""Widgets Helper Library.
+
+A library of `ipywidgets` wrappers for notebook based reports and voila dashboards.
+The library includes both python code and html/css/js elements that can be found in the
+`./widgets` folder.
+"""
+import os
+from jinja2 import Template
+
+
+def stylesheet():
+    """Load a default CSS stylesheet from file."""
+    with open(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "widgets", "style.css")
+    ) as f:
+        style = f.read()
+    return style
+
+
+def price_card(ticker: str, price: str, price_color: str = "neutral_color") -> str:
+    """Prepare a styled HTML element of a 128 by 128 price card.
+
+    Parameters
+    ----------
+    ticker : str
+        Instrument ticker for the price card
+    price : str
+        Instrument price as a string
+    price_color : str, optional
+        The color of the price. Accepts "up_color", "down_color" and default "neutral_color"
+
+    Returns
+    -------
+    str
+        HTML code as string
+    """
+    with open(
+        os.path.join(os.path.dirname(os.path.abspath(__file__)), "widgets", "card.j2")
+    ) as f:
+        template = Template(f.read())
+    card = template.render(ticker=ticker, price=price, price_color=price_color)
+    return card

--- a/gamestonk_terminal/jupyter/dashboards/widgets/card.j2
+++ b/gamestonk_terminal/jupyter/dashboards/widgets/card.j2
@@ -1,0 +1,8 @@
+<div class="container">
+    <div class="card">
+        <div class="contentBx">
+            <h1>{{ ticker }}</h1>
+            <h2 class="{{ price_color }}">{{ price }}</h2>
+        </div>
+    </div>
+</div>

--- a/gamestonk_terminal/jupyter/dashboards/widgets/currencies.json
+++ b/gamestonk_terminal/jupyter/dashboards/widgets/currencies.json
@@ -1,0 +1,237 @@
+{
+    "global": {
+        "tabSetEnableClose": true,
+        "tabSetEnableTabStrip": false,
+        "tabSetTabLocation": "bottom"
+    },
+    "borders": [],
+    "layout": {
+        "type": "row",
+        "id": "#1",
+        "children": [
+            {
+                "type": "tabset",
+                "id": "#2",
+                "children": [
+                    {
+                        "type": "tab",
+                        "id": "#3",
+                        "name": "New section ",
+                        "component": "sub",
+                        "config": {
+                            "model": {
+                                "global": {
+                                    "tabSetEnableClose": true
+                                },
+                                "borders": [],
+                                "layout": {
+                                    "type": "row",
+                                    "id": "#1",
+                                    "children": [
+                                        {
+                                            "type": "row",
+                                            "id": "#930eb3e5-1999-46b8-afc6-01d731dcb211",
+                                            "children": [
+                                                {
+                                                    "type": "row",
+                                                    "id": "#5debcdc6-eaaf-4224-83a7-17f9908a7a78",
+                                                    "height": 145,
+                                                    "children": [
+                                                        {
+                                                            "type": "tabset",
+                                                            "id": "#ca43de5d-5956-4fe3-8f55-94eb954a2886",
+                                                            "width": 142,
+                                                            "children": [
+                                                                {
+                                                                    "type": "tab",
+                                                                    "id": "#ff22f410-6265-4a7b-b975-1dc8676fb138",
+                                                                    "name": "EUR/USD",
+                                                                    "component": "Widget",
+                                                                    "config": {
+                                                                        "layoutID": "#3"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "tabset",
+                                                            "id": "#6bf131b1-a6eb-4b8f-941a-14e0655acd79",
+                                                            "width": 142,
+                                                            "children": [
+                                                                {
+                                                                    "type": "tab",
+                                                                    "id": "#8b10c77b-40f2-40e6-9673-13ddcc8238c1",
+                                                                    "name": "USD/JPY",
+                                                                    "component": "Widget",
+                                                                    "config": {
+                                                                        "layoutID": "#3"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "tabset",
+                                                            "id": "#6939401f-4c4d-41dd-9849-fd3178320122",
+                                                            "width": 142,
+                                                            "children": [
+                                                                {
+                                                                    "type": "tab",
+                                                                    "id": "#7bd5f16d-d127-46f8-86a0-f413feff3b92",
+                                                                    "name": "GBP/USD",
+                                                                    "component": "Widget",
+                                                                    "config": {
+                                                                        "layoutID": "#3"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "tabset",
+                                                            "id": "#61c25933-b899-4d59-aad8-e1e98df13b7d",
+                                                            "width": 142,
+                                                            "children": [
+                                                                {
+                                                                    "type": "tab",
+                                                                    "id": "#762d37fc-312e-4f16-8541-af486fe2ec4f",
+                                                                    "name": "AUD/USD",
+                                                                    "component": "Widget",
+                                                                    "config": {
+                                                                        "layoutID": "#3"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "tabset",
+                                                            "id": "#d44c4bf6-c879-46fc-bb57-80fd352ae872",
+                                                            "width": 142,
+                                                            "children": [
+                                                                {
+                                                                    "type": "tab",
+                                                                    "id": "#fc1a8e88-160f-41d3-b5d8-d4d9abc5ac44",
+                                                                    "name": "USD/CAD",
+                                                                    "component": "Widget",
+                                                                    "config": {
+                                                                        "layoutID": "#3"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "tabset",
+                                                            "id": "#298c01a6-e058-4e2d-8ac6-ebb279716761",
+                                                            "width": 142,
+                                                            "children": [
+                                                                {
+                                                                    "type": "tab",
+                                                                    "id": "#c2dfcb8c-9078-44f1-9118-3beebc3181d4",
+                                                                    "name": "USD/CNY",
+                                                                    "component": "Widget",
+                                                                    "config": {
+                                                                        "layoutID": "#3"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "tabset",
+                                                            "id": "#f544d439-5557-470f-ad2b-8f6168a40b77",
+                                                            "width": 142,
+                                                            "children": [
+                                                                {
+                                                                    "type": "tab",
+                                                                    "id": "#d1f5dcf1-5643-49dd-aa28-725287f1b3f2",
+                                                                    "name": "USD/CHF",
+                                                                    "component": "Widget",
+                                                                    "config": {
+                                                                        "layoutID": "#3"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "tabset",
+                                                            "id": "#bcbbac20-d71f-4e6a-990e-b2a5d0a11255",
+                                                            "width": 142,
+                                                            "children": [
+                                                                {
+                                                                    "type": "tab",
+                                                                    "id": "#65907a81-d976-482a-b1df-45de9317cad2",
+                                                                    "name": "USD/HKD",
+                                                                    "component": "Widget",
+                                                                    "config": {
+                                                                        "layoutID": "#3"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "row",
+                                                    "id": "#410cd13c-0d14-4ada-8aad-5cfc522d1421",
+                                                    "weight": 15,
+                                                    "children": [
+                                                        {
+                                                            "type": "tabset",
+                                                            "id": "#d83b1943-b895-43bd-9f0f-d36672194a58",
+                                                            "width": 256,
+                                                            "children": [
+                                                                {
+                                                                    "type": "tab",
+                                                                    "id": "#044a38ed-6f61-4586-ae3f-8c76c494351b",
+                                                                    "name": "Select",
+                                                                    "component": "Widget",
+                                                                    "config": {
+                                                                        "layoutID": "#3"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        },
+                                                        {
+                                                            "type": "tabset",
+                                                            "id": "#239aa076-2c4d-44da-a9ed-6f8ad9b27c30",
+                                                            "weight": 75,
+                                                            "children": [
+                                                                {
+                                                                    "type": "tab",
+                                                                    "id": "#3f45998e-34f5-42b0-9980-d07f9fff2eb5",
+                                                                    "name": "Historical",
+                                                                    "component": "Widget",
+                                                                    "config": {
+                                                                        "layoutID": "#3"
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    ]
+                                                },
+                                                {
+                                                    "type": "tabset",
+                                                    "id": "#1fd33f67-3fdd-4f36-822a-ac0ee05ad8ab",
+                                                    "weight": 85,
+                                                    "children": [
+                                                        {
+                                                            "type": "tab",
+                                                            "id": "#4b4ab553-fc3a-4984-93ad-99b89def2dc4",
+                                                            "name": "Candle",
+                                                            "component": "Widget",
+                                                            "config": {
+                                                                "layoutID": "#3"
+                                                            }
+                                                        }
+                                                    ]
+                                                }
+                                            ]
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                ],
+                "active": true
+            }
+        ]
+    }
+}

--- a/gamestonk_terminal/jupyter/dashboards/widgets/style.css
+++ b/gamestonk_terminal/jupyter/dashboards/widgets/style.css
@@ -1,0 +1,54 @@
+.container {
+    position: relative;
+}
+
+.container .card {
+    font-family: Consolas, sans-serif;
+    position: relative;
+    width: 128px;
+    height: 128px;
+    background: #000000;
+    border-radius: 5px;
+    border-color: rgb(142, 142, 142);
+    border-style: solid;
+    border-width: 0.5px;
+    overflow: hidden;
+}
+
+.container .card .contentBx {
+    position: absolute;
+    top: 28;
+    bottom: 32;
+    width: 100%;
+    text-align: center;
+    z-index: 10;
+}
+
+.container .card .contentBx h1 {
+    position: relative;
+    font-size: 28;
+    font-weight: 600;
+    letter-spacing: 1px;
+    color: #fff;
+    margin-top: 28px;
+    margin-bottom: 10px;
+}
+
+.container .card .contentBx h2 {
+    position: relative;
+    font-size: 28px;
+    font-weight: 600;
+    letter-spacing: 1px;
+}
+
+.up_color {
+    color: #00ACFF;
+}
+
+.down_color {
+    color: #e4003a;
+}
+
+.neutral_color {
+    color: #ffed00;
+}

--- a/jupyterlab/README.md
+++ b/jupyterlab/README.md
@@ -1,9 +1,24 @@
-# Jupyter Lab Extensions for using Gamestonk Terminal
+# Jupyter Ecosystem integration
+
+The Jupyter ecosystem has created Open Source tools that have become the de-facto
+standard for data related tasks.
+
+This folder contains source code for a bunch of tools that help using the functionality
+of the terminal in connection with Jupyter:
+
+1. Jupyter Lab Extensions for using Gamestonk Terminal
+
+## 1. Jupyter Lab Extensions for using Gamestonk Terminal
+
+Documentation, GST and GST-settings are 3 Jupyter Lab extensions that illustrate how
+the terminal can be integrated with Jupyter Lab based IDEs.
+
+*NOTE: The extensions should be considered prototypes and are not production-ready.*
 
 1. Only bash is supported (only macOS, Linux and WSL). No support for Windows powershell or command prompt.
 2. The input values are not escaped
 
-## Installation
+### Installation
 
 To install the Terminal Launcher and the Settings Extensions run the following commands from the [root folder of the project](/):
 
@@ -16,7 +31,7 @@ jupyter labextension install jupyterlab/gst-settings
 jupyter labextension install jupyterlab/documentation
 ```
 
-## Development setup
+### Development setup
 
 In this section `gst` extension will be used as an example.
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -1256,6 +1256,21 @@ docs = ["sphinx (==3.4.3)", "recommonmark (==0.7.1)", "furo (==2021.4.11b34)", "
 tests = ["pytest (==6.2.5)"]
 
 [[package]]
+name = "ipyflex"
+version = "0.2.2"
+description = "Jupyter Widget Flex Layout"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[package.dependencies]
+ipywidgets = ">=7.0.0"
+
+[package.extras]
+docs = ["jupyter-sphinx", "nbsphinx", "nbsphinx-link", "pytest-check-links", "pypandoc", "recommonmark", "sphinx (>=1.5)", "sphinx-rtd-theme"]
+test = ["pytest (>=4.6)", "pytest-cov", "nbval"]
+
+[[package]]
 name = "ipykernel"
 version = "6.9.2"
 description = "IPython Kernel for Jupyter"
@@ -1339,7 +1354,7 @@ python-versions = "*"
 
 [[package]]
 name = "ipywidgets"
-version = "7.6.5"
+version = "7.7.0"
 description = "IPython HTML widgets for Jupyter"
 category = "main"
 optional = false
@@ -1352,7 +1367,7 @@ ipython-genutils = ">=0.2.0,<0.3.0"
 jupyterlab-widgets = {version = ">=1.0.0", markers = "python_version >= \"3.6\""}
 nbformat = ">=4.2.0"
 traitlets = ">=4.3.1"
-widgetsnbextension = ">=3.5.0,<3.6.0"
+widgetsnbextension = ">=3.6.0,<3.7.0"
 
 [package.extras]
 test = ["pytest (>=3.6.0)", "pytest-cov", "mock"]
@@ -4227,7 +4242,7 @@ watchdog = ["watchdog"]
 
 [[package]]
 name = "widgetsnbextension"
-version = "3.5.2"
+version = "3.6.0"
 description = "IPython HTML widgets for Jupyter"
 category = "main"
 optional = false
@@ -4314,7 +4329,7 @@ prediction = ["tensorflow"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.10"
-content-hash = "80bedf972d6760b4c9d7aa45cd71a216ed822e51db62a85bf4630b5e073f4b27"
+content-hash = "c34697873fe89f912959662b3fa57826735b8b7b17012228a3dad5b91eb8a576"
 
 [metadata.files]
 absl-py = [
@@ -5166,6 +5181,10 @@ interface-meta = [
 investpy = [
     {file = "investpy-1.0.8.tar.gz", hash = "sha256:6a7632a94b484ee07cd54afd416bdc759cd905ba60c62dbb8a8d157229b267c6"},
 ]
+ipyflex = [
+    {file = "ipyflex-0.2.2-py2.py3-none-any.whl", hash = "sha256:bc33f32f8e896a34a417b2260e24efa15ac7baa978f84f1cecc168ddc7a47c1c"},
+    {file = "ipyflex-0.2.2.tar.gz", hash = "sha256:9a70226a410bfd035d6271a7093762bc483e9401d387094078e1c2984051c5f7"},
+]
 ipykernel = [
     {file = "ipykernel-6.9.2-py3-none-any.whl", hash = "sha256:c977cff576b8425a68d3a6916510903833f0f25ed8d5c282a0c51c35de27bd47"},
     {file = "ipykernel-6.9.2.tar.gz", hash = "sha256:4c3cc8cb359f2ead70c30f5504971c0d285e2c1c699d2ce9af0216fe9c9fb17c"},
@@ -5183,8 +5202,8 @@ ipython-genutils = [
     {file = "ipython_genutils-0.2.0.tar.gz", hash = "sha256:eb2e116e75ecef9d4d228fdc66af54269afa26ab4463042e33785b887c628ba8"},
 ]
 ipywidgets = [
-    {file = "ipywidgets-7.6.5-py2.py3-none-any.whl", hash = "sha256:d258f582f915c62ea91023299603be095de19afb5ee271698f88327b9fe9bf43"},
-    {file = "ipywidgets-7.6.5.tar.gz", hash = "sha256:00974f7cb4d5f8d494c19810fedb9fa9b64bffd3cda7c2be23c133a1ad3c99c5"},
+    {file = "ipywidgets-7.7.0-py2.py3-none-any.whl", hash = "sha256:e58ff58bc94d481e91ecb6e13a5cb96a87b6b8ade135e055603d0ca24593df38"},
+    {file = "ipywidgets-7.7.0.tar.gz", hash = "sha256:ab4a5596855a88b83761921c768707d65e5847068139bc1729ddfe834703542a"},
 ]
 iso8601 = [
     {file = "iso8601-0.1.16-py2.py3-none-any.whl", hash = "sha256:906714829fedbc89955d52806c903f2332e3948ed94e31e85037f9e0226b8376"},
@@ -7191,8 +7210,8 @@ werkzeug = [
     {file = "Werkzeug-2.0.3.tar.gz", hash = "sha256:b863f8ff057c522164b6067c9e28b041161b4be5ba4d0daceeaa50a163822d3c"},
 ]
 widgetsnbextension = [
-    {file = "widgetsnbextension-3.5.2-py2.py3-none-any.whl", hash = "sha256:763a9fdc836d141fa080005a886d63f66f73d56dba1fb5961afc239c77708569"},
-    {file = "widgetsnbextension-3.5.2.tar.gz", hash = "sha256:e0731a60ba540cd19bbbefe771a9076dcd2dde90713a8f87f27f53f2d1db7727"},
+    {file = "widgetsnbextension-3.6.0-py2.py3-none-any.whl", hash = "sha256:4fd321cad39fdcf8a8e248a657202d42917ada8e8ed5dd3f60f073e0d54ceabd"},
+    {file = "widgetsnbextension-3.6.0.tar.gz", hash = "sha256:e84a7a9fcb9baf3d57106e184a7389a8f8eb935bf741a5eb9d60aa18cc029a80"},
 ]
 wrapt = [
     {file = "wrapt-1.13.3-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:e05e60ff3b2b0342153be4d1b597bbcfd8330890056b9619f4ad6b8d5c96a81a"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,8 @@ linearmodels = "^4.25"
 black = "22.1"
 boto3 = "^1.21.18"
 undetected-chromedriver = {version = "^3.1.5", optional = true}
+ipywidgets = "^7.7.0"
+ipyflex = "^0.2.2"
 
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
This PR adds a new dashboard that can be used to monitor exchange rates of the most traded currency pairs and see
stats (historical and candle charts) for an arbitrary currency pair.

This is still WIP because it uses alphavantage's endpoints that are limited to 5 requests per minute.

The PR will be updated once we add yfinance to the list of sources in the Forex menu.
